### PR TITLE
Fixed a bug where the terminal would open and immediately close after launching the application.

### DIFF
--- a/src-tauri/src/iracing/service.rs
+++ b/src-tauri/src/iracing/service.rs
@@ -264,14 +264,7 @@ pub async fn start_telemetry_stream(
                         break;
                     }
                     Err(_) => {
-                        let is_running = std::process::Command::new("tasklist")
-                            .arg("/FI")
-                            .arg("IMAGENAME eq iRacingSim64.exe")
-                            .output()
-                            .map(|o| {
-                                String::from_utf8_lossy(&o.stdout).contains("iRacingSim64.exe")
-                            })
-                            .unwrap_or(false);
+                        let is_running = is_iracing_running();
 
                         if !is_running {
                             warn!("iRacingSim64.exe is not running. Disconnecting.");
@@ -523,4 +516,16 @@ fn emit_domain_frames(
             warn!("Failed to emit environment: {}", e);
         }
     }
+}
+
+fn is_iracing_running() -> bool {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    std::process::Command::new("tasklist")
+        .arg("/FI")
+        .arg("IMAGENAME eq iRacingSim64.exe")
+        .creation_flags(CREATE_NO_WINDOW)
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).contains("iRacingSim64.exe"))
+        .unwrap_or(false)
 }


### PR DESCRIPTION
Cause: In service.rs:267, when the connection to iRacing was lost, tasklist.exe was launched via std::process::Command without the CREATE_NO_WINDOW flag. Windows displayed a console window for a split second, even though windows_subsystem = "windows" in main.rs—this attribute hides the console only for the application process itself, not for child processes.

Fix: Moved the call to the is_iracing_running() function with the .creation_flags(0x08000000) (CREATE_NO_WINDOW) flag via std::os::windows::process::CommandExt.

Closed #41 