### PR TITLE
refactor(fuel-widget): simplify metrics — remove NOW/LAP, reduce chart padding

### DIFF
--- a/src-tauri/src/computations/fuel.rs
+++ b/src-tauri/src/computations/fuel.rs
@@ -73,7 +73,6 @@ impl FuelState {
 #[serde(rename_all = "camelCase")]
 pub struct FuelComputedFrame {
     pub avg_per_lap: f32,
-    pub current_use_per_lap: f32,
     pub laps_remaining: f32,
     pub laps_to_finish: Option<f32>,
     /// Positive = surplus liters, negative = deficit
@@ -124,8 +123,6 @@ pub fn compute(
     fuel_state: &FuelState,
 ) -> Option<FuelComputedFrame> {
     let fuel_level = frame.fuel_level;
-
-    let current_use_per_lap = instant_avg(frame, session).unwrap_or(0.0);
 
     let avg_per_lap = fuel_state.avg().or_else(|| instant_avg(frame, session))?;
 
@@ -179,7 +176,6 @@ pub fn compute(
 
     Some(FuelComputedFrame {
         avg_per_lap,
-        current_use_per_lap,
         laps_remaining,
         laps_to_finish,
         shortage,

--- a/src/components/widgets/FuelWidget/FuelChart/chart-renderers.ts
+++ b/src/components/widgets/FuelWidget/FuelChart/chart-renderers.ts
@@ -104,8 +104,8 @@ export const drawBarChart = (
   const plotW = w - FUEL_CHART_CONFIG.Y_LABEL_W;
   const plotH = h - FUEL_CHART_CONFIG.X_LABEL_H;
 
-  const min = Math.min(...data) * 0.88;
-  const max = Math.max(...data) * 1.08;
+  const min = Math.min(...data) * FUEL_CHART_CONFIG.MIN_SCALE;
+  const max = Math.max(...data) * FUEL_CHART_CONFIG.MAX_SCALE;
   const range = max - min || 1;
 
   const barW = FUEL_CHART_CONFIG.BAR_WIDTH;
@@ -144,8 +144,8 @@ export const drawLineChart = (
   const plotW = w - FUEL_CHART_CONFIG.Y_LABEL_W;
   const plotH = h - FUEL_CHART_CONFIG.X_LABEL_H;
 
-  const min = Math.min(...data) * 0.92;
-  const max = Math.max(...data) * 1.08;
+  const min = Math.min(...data) * FUEL_CHART_CONFIG.MIN_SCALE_LINE;
+  const max = Math.max(...data) * FUEL_CHART_CONFIG.MAX_SCALE;
   const range = max - min || 1;
 
   const toY = (v: number) => plotH - ((v - min) / range) * plotH;

--- a/src/components/widgets/FuelWidget/FuelChart/chart-renderers.ts
+++ b/src/components/widgets/FuelWidget/FuelChart/chart-renderers.ts
@@ -115,13 +115,6 @@ export const drawBarChart = (
 
   drawGridLines(ctx, plotH, 0, plotW);
 
-  if (avg !== null) {
-    const avgY = plotH - toBarH(avg);
-    drawAvgLine(ctx, avgY, plotW);
-  }
-
-  drawYLabels(ctx, min, max, plotH, w);
-
   data.forEach((v, i) => {
     const x = i * stride;
     const bh = toBarH(v);
@@ -129,6 +122,12 @@ export const drawBarChart = (
     ctx.fillRect(x, plotH - bh, barW, bh);
   });
 
+  if (avg !== null) {
+    const avgY = plotH - toBarH(avg);
+    drawAvgLine(ctx, avgY, plotW);
+  }
+
+  drawYLabels(ctx, min, max, plotH, w);
   drawXLabels(ctx, n, stride, barW, plotH);
 };
 
@@ -154,12 +153,6 @@ export const drawLineChart = (
 
   drawGridLines(ctx, plotH, 0, plotW);
 
-  if (avg !== null) {
-    drawAvgLine(ctx, toY(avg), plotW);
-  }
-
-  drawYLabels(ctx, min, max, plotH, w);
-
   ctx.beginPath();
   ctx.strokeStyle = FUEL_COLORS.primary;
   ctx.lineWidth = 1.5;
@@ -179,6 +172,12 @@ export const drawLineChart = (
     ctx.fillStyle = barColor(v, avg);
     ctx.fill();
   });
+
+  if (avg !== null) {
+    drawAvgLine(ctx, toY(avg), plotW);
+  }
+
+  drawYLabels(ctx, min, max, plotH, w);
 
   const lineStride = data.length > 1 ? plotW / (data.length - 1) : plotW;
   const maxLabelW =

--- a/src/components/widgets/FuelWidget/FuelWidget.module.scss
+++ b/src/components/widgets/FuelWidget/FuelWidget.module.scss
@@ -235,7 +235,7 @@
 }
 
 .chart {
-  padding: rem(4) rem(8) rem(8);
+  padding: 0 rem(8) rem(8);
   display: flex;
   flex-direction: column;
   gap: rem(4);

--- a/src/components/widgets/FuelWidget/FuelWidget.module.scss
+++ b/src/components/widgets/FuelWidget/FuelWidget.module.scss
@@ -241,13 +241,6 @@
   gap: rem(4);
 }
 
-.chartLabel {
-  font-family: $font-mono;
-  font-size: $font-size-xs;
-  color: $color-text-muted;
-  letter-spacing: 1px;
-}
-
 .chartCanvas {
   width: 100%;
   height: rem(200);

--- a/src/components/widgets/FuelWidget/FuelWidget.tsx
+++ b/src/components/widgets/FuelWidget/FuelWidget.tsx
@@ -10,7 +10,6 @@ interface FuelWidgetProps {
   fuelLevel: number | null;
   fuelMax: number | null;
   avgPerLap: FuelCalculations['avgPerLap'];
-  currentUsePerLap: number | null;
   lapsRemaining: FuelCalculations['lapsRemaining'];
   shortage: FuelCalculations['shortage'];
   fuelToAddWithBuffer: FuelCalculations['fuelToAddWithBuffer'];
@@ -52,7 +51,6 @@ export const FuelWidget = ({
   fuelLevel,
   fuelMax,
   avgPerLap,
-  currentUsePerLap,
   lapsRemaining,
   shortage,
   fuelToAddWithBuffer,
@@ -109,13 +107,6 @@ export const FuelWidget = ({
         <div className={styles.row}>
           <span className={styles.rowLabel}>AVG/LAP</span>
           <span className={styles.rowValue}>{formatFuelLiters(avgPerLap)}</span>
-        </div>
-
-        <div className={styles.row}>
-          <span className={styles.rowLabel}>NOW/LAP</span>
-          <span className={`${styles.rowValue} ${styles.rowValueMuted}`}>
-            {formatFuelLiters(currentUsePerLap)}
-          </span>
         </div>
 
         <div className={styles.row}>

--- a/src/components/widgets/FuelWidget/FuelWidget.tsx
+++ b/src/components/widgets/FuelWidget/FuelWidget.tsx
@@ -130,7 +130,6 @@ export const FuelWidget = ({
 
       {showChart && lapFuelHistory.length >= 2 && (
         <div className={styles.chart}>
-          <span className={styles.chartLabel}>USE/LAP HISTORY</span>
           <FuelChart history={lapFuelHistory} chartType={chartType} />
         </div>
       )}

--- a/src/components/widgets/FuelWidget/FuelWidgetContainer.tsx
+++ b/src/components/widgets/FuelWidget/FuelWidgetContainer.tsx
@@ -31,7 +31,6 @@ export const FuelWidgetContainer = observer(() => {
       fuelLevel={fuelLevel}
       fuelMax={fuelMax}
       avgPerLap={fuel?.avgPerLap ?? null}
-      currentUsePerLap={fuel?.currentUsePerLap ?? null}
       lapsRemaining={lapsRemaining}
       shortage={fuel?.shortage ?? null}
       fuelToAddWithBuffer={fuelToAddWithBuffer}

--- a/src/components/widgets/FuelWidget/fuel-constants.ts
+++ b/src/components/widgets/FuelWidget/fuel-constants.ts
@@ -38,6 +38,12 @@ export const FUEL_CHART_CONFIG = {
   LABEL_CHAR_W: 7,
   /** Minimum gap between X-axis labels in pixels */
   LABEL_MIN_GAP: 2,
+  /** Scale factor applied to min value to add bottom padding in chart */
+  MIN_SCALE: 0.88,
+  /** Scale factor applied to min value to add bottom padding in line chart */
+  MIN_SCALE_LINE: 0.92,
+  /** Scale factor applied to max value to add top padding in chart */
+  MAX_SCALE: 1.02,
 } as const;
 
 export const FUEL_THRESHOLDS = {

--- a/src/components/widgets/FuelWidget/fuel-constants.ts
+++ b/src/components/widgets/FuelWidget/fuel-constants.ts
@@ -43,7 +43,7 @@ export const FUEL_CHART_CONFIG = {
   /** Scale factor applied to min value to add bottom padding in line chart */
   MIN_SCALE_LINE: 0.92,
   /** Scale factor applied to max value to add top padding in chart */
-  MAX_SCALE: 1.02,
+  MAX_SCALE: 1.05,
 } as const;
 
 export const FUEL_THRESHOLDS = {

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -836,7 +836,6 @@ export type Frequency = {
 
 export type FuelComputedFrame = {
   avgPerLap: number;
-  currentUsePerLap: number;
   lapsRemaining: number;
   lapsToFinish: number | null;
   /**


### PR DESCRIPTION
Closed #50 
  - Removed NOW/LAP (instant fuel per lap) — unreliable at standstill and during idle, showed misleading low values when car was not moving respond to throttle input when stationary despite fuel actually being consumed                                                                             
  - Keep only AVG/LAP + LAPS LEFT — both are always accurate and actionable
  - Reduced chart top padding from 8% to 2% (MAX_SCALE: 1.08 → 1.02) to eliminate excess whitespace above bars/line
  - Extracted magic scale factors (MIN_SCALE, MIN_SCALE_LINE, MAX_SCALE) into named constants in fuel-constants.ts