### PR TITLE
fix(lap-count): accurate lap display in Timer and Standings header

### DIFF
--- a/src-tauri/src/iracing/frames/mod.rs
+++ b/src-tauri/src/iracing/frames/mod.rs
@@ -132,6 +132,8 @@ pub(crate) struct AllFieldsFrame {
     pub session_time: Option<f64>,
     #[field_name = "SessionTimeRemain"]
     pub session_time_remain: Option<f64>,
+    #[field_name = "SessionLapsRemainEx"]
+    pub session_laps_remain_ex: Option<i32>,
     #[field_name = "SessionState"]
     pub session_state: Option<i32>,
     #[bitfield_map(name = "SessionFlags", decoder = "bitfield_to_u32")]

--- a/src-tauri/src/iracing/frames/session.rs
+++ b/src-tauri/src/iracing/frames/session.rs
@@ -40,6 +40,10 @@ pub struct SessionFrame {
     /// @see https://sajax.github.io/irsdkdocs/telemetry/sessiontimeofday/
     pub session_time_of_day: Option<f32>,
 
+    /// Laps remaining in the session (leader-based, preferred over SessionLapsRemain)
+    /// @see https://sajax.github.io/irsdkdocs/telemetry/sessionlapsremainex/
+    pub session_laps_remain_ex: Option<i32>,
+
     /// Index of the player's car in CarIdx arrays
     /// @see https://sajax.github.io/irsdkdocs/telemetry/playercaridx/
     pub player_car_idx: Option<i32>,
@@ -59,6 +63,7 @@ impl From<&AllFieldsFrame> for SessionFrame {
         Self {
             session_time: f.session_time,
             session_time_remain: f.session_time_remain,
+            session_laps_remain_ex: f.session_laps_remain_ex,
             session_state: f.session_state.map(SessionState::from),
             session_flags: f.session_flags,
             session_num: f.session_num,

--- a/src/components/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
+++ b/src/components/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
@@ -6,7 +6,6 @@ import type { DriverEntry } from '../../../../types/bindings';
 import { widgetSettingsStore } from '../../../../store/widget-settings.store';
 import type { SessionInfoData, WeekendInfo } from '../../../../types/bindings';
 import { telemetryStore } from '../../../../store/iracing';
-import { resolveSessionLaps } from '../../../../utils/telemetry-format';
 
 import styles from './SessionHeader.module.scss';
 
@@ -42,11 +41,7 @@ export const SessionHeader = observer(
     const currentSession = sessions?.[sessionInfo?.CurrentSessionNum ?? 0];
     const trackName = weekendInfo?.TrackDisplayName ?? '';
 
-    const sessionLapsDisplay = resolveSessionLaps(
-      currentSession?.SessionLaps,
-      currentSession?.SessionTime,
-      telemetryStore.leaderBestLapTime
-    );
+    const currentLap = telemetryStore.lapTiming?.lap ?? null;
 
     const env = telemetryStore.environment;
     const airCelsius =
@@ -71,11 +66,11 @@ export const SessionHeader = observer(
           {currentSession && (
             <span>{currentSession.SessionType?.toUpperCase()}</span>
           )}
-
-          {sessionLapsDisplay && <span>Laps: {sessionLapsDisplay}</span>}
         </div>
 
         <div className={styles.sessionRight}>
+          {currentLap !== null && <span>LAP {currentLap}</span>}
+
           {settings.showTotalDrivers && (
             <span className={styles.sessionDriverCount}>
               <Users size={10} />

--- a/src/components/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
+++ b/src/components/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
@@ -41,7 +41,11 @@ export const SessionHeader = observer(
     const currentSession = sessions?.[sessionInfo?.CurrentSessionNum ?? 0];
     const trackName = weekendInfo?.TrackDisplayName ?? '';
 
-    const currentLap = telemetryStore.lapTiming?.lap ?? null;
+    // Leader's lap reflects overall session progress; player lap is misleading when lapped.
+    const leaderLap =
+      driverEntries.length > 0
+        ? Math.max(...driverEntries.map((e) => e.lap))
+        : null;
 
     const env = telemetryStore.environment;
     const airCelsius =
@@ -69,7 +73,7 @@ export const SessionHeader = observer(
         </div>
 
         <div className={styles.sessionRight}>
-          {currentLap !== null && <span>LAP {currentLap}</span>}
+          {leaderLap !== null && <span>LAP {leaderLap}</span>}
 
           {settings.showTotalDrivers && (
             <span className={styles.sessionDriverCount}>

--- a/src/components/widgets/TimerWidget/TimerWidgetContainer.tsx
+++ b/src/components/widgets/TimerWidget/TimerWidgetContainer.tsx
@@ -163,8 +163,13 @@ export const TimerWidgetContainer = observer(() => {
     playerCarIdx !== null ? (carIdx?.car_idx_lap[playerCarIdx] ?? null) : null;
 
   const sessionLapsRemainEx = session?.session_laps_remain_ex ?? null;
-  const totalLaps =
-    sessionLapsRemainEx !== null && sessionLapsRemainEx >= 0
+  const fixedSessionLaps = currentSession?.SessionLaps;
+  const isFixedLapRace =
+    fixedSessionLaps != null && fixedSessionLaps.toLowerCase() !== 'unlimited';
+
+  const totalLaps = isFixedLapRace
+    ? (fixedSessionLaps ?? null)
+    : sessionLapsRemainEx !== null && sessionLapsRemainEx >= 0
       ? String(sessionLapsRemainEx)
       : null;
 

--- a/src/components/widgets/TimerWidget/TimerWidgetContainer.tsx
+++ b/src/components/widgets/TimerWidget/TimerWidgetContainer.tsx
@@ -6,7 +6,7 @@ import { telemetryStore } from '../../../store/iracing';
 import { widgetSettingsStore } from '../../../store/widget-settings.store';
 import { useAutoSizeWidget } from '../../../hooks/useAutoSizeWidget';
 import { SessionState as BindingSessionState } from '../../../types/bindings';
-import { resolveSessionLaps } from '../../../utils/telemetry-format';
+
 import type { FlagState } from './TimerWidget';
 import { TimerWidget } from './TimerWidget';
 
@@ -162,13 +162,10 @@ export const TimerWidgetContainer = observer(() => {
   const currentLap =
     playerCarIdx !== null ? (carIdx?.car_idx_lap[playerCarIdx] ?? null) : null;
 
+  const sessionLapsRemainEx = session?.session_laps_remain_ex ?? null;
   const totalLaps =
-    sessionNum !== null
-      ? resolveSessionLaps(
-          currentSession?.SessionLaps,
-          currentSession?.SessionTime,
-          telemetryStore.leaderBestLapTime
-        )
+    sessionLapsRemainEx !== null && sessionLapsRemainEx >= 0
+      ? String(sessionLapsRemainEx)
       : null;
 
   const position = lap?.player_car_position ?? null;

--- a/src/store/iracing/telemetry.store.ts
+++ b/src/store/iracing/telemetry.store.ts
@@ -55,15 +55,6 @@ class TelemetryStore {
     return this.sessionInfo?.WeekendInfo ?? null;
   }
 
-  get leaderBestLapTime(): number | null {
-    const times = this.carIdx?.car_idx_best_lap_time;
-    if (!times) return null;
-    return times.reduce<number | null>((best, t) => {
-      if (t > 0 && (best === null || t < best)) return t;
-      return best;
-    }, null);
-  }
-
   /**
    * Returns how many positions a car has gained (positive) or lost (negative)
    * relative to its start position in the current session.

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -1151,6 +1151,11 @@ export type SessionFrame = {
    */
   session_time_of_day: number | null;
   /**
+   * Laps remaining in the session (leader-based, preferred over SessionLapsRemain)
+   * @see https://sajax.github.io/irsdkdocs/telemetry/sessionlapsremainex/
+   */
+  session_laps_remain_ex: number | null;
+  /**
    * Index of the player's car in CarIdx arrays
    * @see https://sajax.github.io/irsdkdocs/telemetry/playercaridx/
    */

--- a/src/utils/telemetry-format.ts
+++ b/src/utils/telemetry-format.ts
@@ -100,35 +100,3 @@ export function formatPercent(fraction: number | null): string {
 export function clampNormalized(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
-
-export const parseSessionSeconds = (
-  sessionTime: string | null | undefined
-): number | null => {
-  if (!sessionTime || sessionTime.toLowerCase() === 'unlimited') return null;
-  const n = parseFloat(sessionTime);
-  return isFinite(n) && n > 0 ? n : null;
-};
-
-export const estimateTotalLaps = (
-  sessionTimeSecs: number,
-  leaderBestLapTimeSecs: number
-): number => {
-  const fittingLaps = Math.floor(sessionTimeSecs / leaderBestLapTimeSecs);
-  return fittingLaps + 1;
-};
-
-export const resolveSessionLaps = (
-  sessionLaps: string | null | undefined,
-  sessionTime: string | null | undefined,
-  leaderBestLapTime: number | null
-): string | null => {
-  if (!sessionLaps) return null;
-  if (sessionLaps.toLowerCase() !== 'unlimited') return sessionLaps;
-
-  const sessionTimeSecs = parseSessionSeconds(sessionTime);
-  if (!sessionTimeSecs) return sessionLaps;
-
-  if (leaderBestLapTime === null) return sessionLaps;
-
-  return String(estimateTotalLaps(sessionTimeSecs, leaderBestLapTime));
-};


### PR DESCRIPTION
Summary                                                   

  - SessionLapsRemainEx telemetry field added to AllFieldsFrame and SessionFrame (Rust) — the iRacing-recommended field for real remaining laps based on leader position
  - TimerWidget denominator fix: fixed-lap races show total laps (SessionLaps, constant); timed/unlimited races show SessionLapsRemainEx as a countdown — previously both always showed the static
  session YAML value, ignoring pit time lost
  - Standings header lap: replaced total-laps label with leader's current lap (derived as Math.max over driverEntries[].lap), so the header reflects actual session progress rather than a static
  limit or the player's lap (which is misleading when lapped)
  - Dead code removed: resolveSessionLaps, estimateTotalLaps, parseSessionSeconds utilities and leaderBestLapTime getter deleted — no longer used anywhere