### PR TITLE
fix(sync): sync drag mode from overlay back to main window

### DIFF
--- a/src/store/sync/events.ts
+++ b/src/store/sync/events.ts
@@ -6,6 +6,18 @@ import { widgetSettingsStore } from '../widget-settings.store';
 import type { UnitSystem } from '../../types/units';
 import type { WidgetConfig } from '../../types/widget-settings';
 
+export const setupMainListeners = async (): Promise<UnlistenFn[]> => {
+  const unlistens: UnlistenFn[] = [];
+
+  unlistens.push(
+    await listen<boolean>('drag-mode-changed', (e) => {
+      runInAction(() => appSettingsStore.setDragMode(e.payload));
+    })
+  );
+
+  return unlistens;
+};
+
 export const setupOverlayListeners = async (): Promise<UnlistenFn[]> => {
   const unlistens: UnlistenFn[] = [];
 

--- a/src/store/sync/index.ts
+++ b/src/store/sync/index.ts
@@ -12,6 +12,7 @@ import {
 } from './persistence';
 import { setupHotkeys, cleanupHotkeys } from './hotkeys';
 import {
+  setupMainListeners,
   setupOverlayListeners,
   emitDragMode,
   emitHideAllWidgets,
@@ -48,6 +49,8 @@ export const initMainSync = async () => {
           runInAction(() => widgetSettingsStore.setWidgets(e.payload));
         }
       );
+
+      const mainUnlistens = await setupMainListeners();
 
       const disposers = [
         reaction(
@@ -144,6 +147,7 @@ export const initMainSync = async () => {
 
       return () => {
         void overlayLayoutUnlisten();
+        mainUnlistens.forEach((u) => u());
         disposers.forEach((d) => d());
         cleanupHotkeys();
         mainSyncInitPromise = null;
@@ -171,5 +175,17 @@ export const initOverlaySync = async () => {
 
   const unlistens = await setupOverlayListeners();
 
-  return () => unlistens.forEach((u) => u());
+  const disposers = [
+    reaction(
+      () => appSettingsStore.dragMode,
+      (v) => {
+        void emitDragMode(v);
+      }
+    ),
+  ];
+
+  return () => {
+    unlistens.forEach((u) => u());
+    disposers.forEach((d) => d());
+  };
 };


### PR DESCRIPTION
  When the "Exit Edit Mode" button was clicked in the overlay, it updated
  the overlay's store but the main window had no listener for the event.
  Added setupMainListeners (listening to drag-mode-changed) in initMainSync,
  and a reaction in initOverlaySync to emit drag-mode-changed when the
  overlay's dragMode changes

Closed #94 