### PR TITLE
remove trend icon, show class position, fix class colors

### DIFF
--- a/src-tauri/src/computations/fuel.rs
+++ b/src-tauri/src/computations/fuel.rs
@@ -42,21 +42,26 @@ impl FuelState {
             if current_lap < self.last_lap && self.last_lap >= 0 {
                 self.lap_fuel_history.clear();
             }
+
             self.last_lap = current_lap;
             self.last_lap_start_fuel = Some(fuel_level);
+
             return;
         }
 
         if current_lap != self.last_lap {
             if let Some(start_fuel) = self.last_lap_start_fuel {
                 let used = start_fuel - fuel_level;
+
                 if used > MIN_RECORDED_FUEL_USE && used < MAX_REALISTIC_LAP_FUEL {
                     self.lap_fuel_history.push(used);
+
                     if self.lap_fuel_history.len() > MAX_LAP_FUEL_HISTORY {
                         self.lap_fuel_history.remove(0);
                     }
                 }
             }
+
             self.last_lap = current_lap;
             self.last_lap_start_fuel = Some(fuel_level);
         }
@@ -66,7 +71,9 @@ impl FuelState {
         if self.lap_fuel_history.is_empty() {
             return None;
         }
+
         let sum: f32 = self.lap_fuel_history.iter().sum();
+
         Some(sum / self.lap_fuel_history.len() as f32)
     }
 }
@@ -138,8 +145,10 @@ pub fn compute(
     });
 
     let current_session_num = session_num.unwrap_or(session.session_info.current_session_num);
+
     let sessions = &session.session_info.sessions;
     let current_session = sessions.get(current_session_num as usize);
+
     let session_laps = current_session
         .map(|s| s.session_laps.as_str())
         .unwrap_or("unlimited");
@@ -149,13 +158,18 @@ pub fn compute(
     let laps_to_finish: Option<f32> = if !is_timed_race {
         let total = session_laps.parse::<f32>().ok()?;
         let current_lap = frame.lap.unwrap_or(0) as f32;
+
         let lap_dist_pct = frame.lap_dist_pct.unwrap_or(0.0);
+
         Some(total - current_lap - lap_dist_pct)
     } else {
         let best_lap = frame.lap_best_lap_time.filter(|&t| t > 0.0);
         let last_lap = frame.lap_last_lap_time.filter(|&t| t > 0.0);
+
         let lap_time_sec = best_lap.or(last_lap)?;
+
         let remain = frame.session_time_remain.filter(|&t| t > 0.0)?;
+
         Some(remain as f32 / lap_time_sec)
     };
 

--- a/src-tauri/src/computations/lap_delta.rs
+++ b/src-tauri/src/computations/lap_delta.rs
@@ -75,7 +75,9 @@ fn sectors_checksum(session: &SessionInfo) -> u64 {
         .unwrap_or(&[]);
 
     const MULTIPLIER: u64 = 6_364_136_223_846_793_005;
+
     let mut h: u64 = sectors.len() as u64;
+
     for s in sectors {
         if let (Some(num), Some(pct)) = (s.sector_num, s.sector_start_pct) {
             h = h.wrapping_mul(MULTIPLIER).wrapping_add(num as u64);
@@ -143,6 +145,7 @@ pub fn compute(
 
     if is_reset {
         handle_reset(&mut locked, sector_count);
+
         return build_frame(&locked, -1, 0.0);
     }
 
@@ -163,6 +166,7 @@ pub fn compute(
             lap_dist_pct,
             current_lap_time,
         );
+
         return build_frame(&locked, current_sector_idx, current_sector_fraction);
     }
 
@@ -197,12 +201,14 @@ pub fn compute(
 
 fn update_sector_cache(locked: &mut LapDeltaState, session: &SessionInfo) {
     let checksum = sectors_checksum(session);
+
     if locked.sectors_checksum != checksum {
         locked.sectors_checksum = checksum;
         locked.cached_sector_pcts = get_sector_pcts(session);
     }
 
     let sector_count = locked.cached_sector_pcts.len();
+
     if locked.sector_count != sector_count {
         locked.sector_times = vec![None; sector_count];
         locked.personal_best_lap_sectors = vec![None; sector_count];
@@ -226,12 +232,14 @@ fn handle_reset(locked: &mut LapDeltaState, sector_count: usize) {
 
 fn find_current_sector(locked: &LapDeltaState, lap_dist_pct: f64) -> i32 {
     let mut current_sector_idx = 0i32;
+
     for (i, &pct) in locked.cached_sector_pcts.iter().enumerate().rev() {
         if pct <= lap_dist_pct {
             current_sector_idx = i as i32;
             break;
         }
     }
+
     current_sector_idx
 }
 
@@ -242,12 +250,15 @@ fn compute_sector_fraction(
 ) -> f32 {
     let idx = current_sector_idx as usize;
     let start = locked.cached_sector_pcts.get(idx).copied().unwrap_or(0.0);
+
     let end = locked
         .cached_sector_pcts
         .get(idx + 1)
         .copied()
         .unwrap_or(1.0);
+
     let len = end - start;
+
     if len > 0.0 {
         ((lap_dist_pct - start) / len).clamp(0.0, 1.0) as f32
     } else {
@@ -280,6 +291,7 @@ fn handle_lap_change(
 
     // Save personal best if this completed lap is faster and all sectors valid.
     let lap_last_lap_time = last_lap_time_f64 as f32;
+
     if lap_last_lap_time > 0.0 && lap_last_lap_time < MAX_REASONABLE_LAP_TIME {
         let all_valid = locked.sector_times.iter().all(|t| t.is_some());
         if all_valid
@@ -319,6 +331,7 @@ fn init_state_on_first_lap(
     locked.sector_entry_time = current_lap_time;
     locked.last_frame_pct = lap_dist_pct;
     locked.last_frame_time = current_lap_time;
+
     if !on_pit_road && is_on_track {
         locked.is_sector_start_valid = true;
     }
@@ -338,6 +351,7 @@ fn handle_sector_change(
         .unwrap_or(0.0);
 
     let mut interpolated_time = current_lap_time;
+
     if locked.last_frame_pct >= 0.0
         && lap_dist_pct > locked.last_frame_pct
         && sector_start_pct > locked.last_frame_pct
@@ -347,6 +361,7 @@ fn handle_sector_change(
         let time_range = current_lap_time - locked.last_frame_time;
         let dist_to_sector = sector_start_pct - locked.last_frame_pct;
         let fraction = dist_to_sector / dist_range;
+
         interpolated_time = locked.last_frame_time + time_range * fraction;
     }
 
@@ -357,6 +372,7 @@ fn handle_sector_change(
         let elapsed = (interpolated_time - locked.sector_entry_time) as f32;
         if elapsed > 0.0 && elapsed < MAX_REASONABLE_SECTOR_TIME {
             let idx = locked.last_sector_idx as usize;
+
             if idx < sector_count {
                 locked.sector_times[idx] = Some(elapsed);
             }
@@ -364,6 +380,7 @@ fn handle_sector_change(
     }
 
     let was_emerging = locked.last_sector_idx == -1;
+
     locked.last_sector_idx = current_sector_idx;
     locked.sector_entry_time = interpolated_time;
 
@@ -378,11 +395,13 @@ fn handle_sector_change(
 
 fn update_live_sector(locked: &mut LapDeltaState, current_sector_idx: i32, current_lap_time: f64) {
     let sector_count = locked.sector_count;
+
     if locked.is_sector_start_valid
         && current_sector_idx >= 0
         && (current_sector_idx as usize) < sector_count
     {
         let live_elapsed = (current_lap_time - locked.sector_entry_time) as f32;
+
         if live_elapsed >= 0.0 {
             locked.sector_times[current_sector_idx as usize] = Some(live_elapsed);
         }
@@ -484,6 +503,7 @@ mod tests {
 
         let locked = state.lock().unwrap();
         let elapsed = locked.sector_times[0].unwrap();
+
         assert!((elapsed - 50.0).abs() < 0.001);
         assert!((locked.sector_entry_time - 50.0).abs() < 0.001);
         assert_eq!(locked.last_sector_idx, 1);
@@ -508,12 +528,14 @@ mod tests {
         });
 
         let mut frame = create_mock_frame(0.1, 5.0);
+
         frame.lap = Some(2);
         frame.lap_last_lap_time = Some(100.0);
 
         let _result = compute(&frame, &session, &state);
 
         let locked = state.lock().unwrap();
+
         assert_eq!(locked.last_lap, 2);
         assert_eq!(locked.last_sector_idx, 0);
         assert_eq!(locked.sector_times[1], Some(20.0));

--- a/src-tauri/src/computations/pit_stops.rs
+++ b/src-tauri/src/computations/pit_stops.rs
@@ -63,14 +63,17 @@ pub fn compute(
         .get(player_idx as usize)
         .copied()
         .unwrap_or(false);
+
     let was = state.was_on_pit_road.load(Ordering::Relaxed);
 
     if on_pit && !was {
         state.count.fetch_add(1, Ordering::Relaxed);
     }
+
     state.was_on_pit_road.store(on_pit, Ordering::Relaxed);
 
     let stops = state.count.load(Ordering::Relaxed);
+
     Some(PitStopsFrame {
         player_stops: stops,
     })

--- a/src-tauri/src/computations/proximity.rs
+++ b/src-tauri/src/computations/proximity.rs
@@ -59,14 +59,19 @@ pub struct ProximityFrame {
 
 pub fn parse_track_length(s: &str) -> f32 {
     let s = s.trim();
+
     if let Some(km_idx) = s.find("km") {
         let num_str = s[..km_idx].trim();
+
         return num_str.parse::<f32>().unwrap_or(0.0) * 1000.0;
     }
+
     if let Some(mi_idx) = s.find("mi") {
         let num_str = s[..mi_idx].trim();
+
         return num_str.parse::<f32>().unwrap_or(0.0) * 1609.34;
     }
+
     0.0
 }
 
@@ -75,10 +80,12 @@ fn spotter_flags(car_left_right: i32) -> (bool, bool) {
         car_left_right,
         CLR_CAR_LEFT | CLR_CAR_LEFT_RIGHT | CLR_CARS_2_LEFT
     );
+
     let right = matches!(
         car_left_right,
         CLR_CAR_RIGHT | CLR_CAR_LEFT_RIGHT | CLR_CARS_2_RIGHT
     );
+
     (left, right)
 }
 
@@ -141,14 +148,17 @@ pub fn compute(
         if i == player_idx {
             continue;
         }
+
         if pct < 0.0 {
             continue;
         }
+
         if on_pit_road.get(i).copied().unwrap_or(false) {
             continue;
         }
 
         let mut diff = pct - player_pct;
+
         if diff > 0.5 {
             diff -= 1.0;
         } else if diff < -0.5 {
@@ -156,6 +166,7 @@ pub fn compute(
         }
 
         let lon_dist = diff * track_length_m;
+
         if lon_dist.abs() <= MAX_SEARCH_DIST_M {
             cars.push((i as i32, lon_dist));
         }
@@ -172,6 +183,7 @@ pub fn compute(
         .map(|&(idx, lon_dist)| {
             let clearance = lon_dist.abs();
             let is_alongside = clearance < ALONGSIDE_THRESHOLD_M;
+
             let lateral_side = if is_alongside {
                 if has_left && has_right {
                     if lon_dist >= 0.0 {
@@ -260,9 +272,11 @@ fn compute_radar_distances(
 
         if car.longitudinal_dist > BUMPER_THRESHOLD_M {
             let gap = (car.longitudinal_dist - car_length_m).max(0.0);
+
             front_dist = front_dist.min(gap);
         } else if car.longitudinal_dist < -BUMPER_THRESHOLD_M {
             let gap = (car.longitudinal_dist.abs() - car_length_m).max(0.0);
+
             rear_dist = rear_dist.min(gap);
         }
     }

--- a/src-tauri/src/computations/proximity.rs
+++ b/src-tauri/src/computations/proximity.rs
@@ -58,7 +58,8 @@ pub struct ProximityFrame {
 }
 
 pub fn parse_track_length(s: &str) -> f32 {
-    let s = s.trim();
+    let s = s.trim().to_lowercase();
+    let s = s.as_str();
 
     if let Some(km_idx) = s.find("km") {
         let num_str = s[..km_idx].trim();

--- a/src-tauri/src/computations/standings.rs
+++ b/src-tauri/src/computations/standings.rs
@@ -224,27 +224,35 @@ pub fn compute(
         result
     };
 
+    let mut locked_state = lock_or_recover(state);
+
     let mut entries: Vec<DriverEntry> = deduped_drivers
         .iter()
         .filter(|d| {
             if d.car_is_pace_car == Some(1) || d.is_spectator == Some(1) {
                 return false;
             }
+
             let idx = d.car_idx as usize;
+
             if idx >= frame.car_idx_position.len() {
                 return false;
             }
+
             if d.car_idx == player_car_idx {
                 return true;
             }
+
             let pos = frame.car_idx_position.get(idx).copied().unwrap_or(0);
             let lap_pct = frame.car_idx_lap_dist_pct.get(idx).copied().unwrap_or(-1.0);
+
             pos > 0 || lap_pct >= 0.0
         })
         .map(|driver| {
             let idx = driver.car_idx as usize;
 
             let tire_compound_idx = frame.car_idx_tire_compound.get(idx).copied().unwrap_or(-1);
+
             let tire_compound = if tire_compound_idx >= 0 {
                 driver_tires
                     .iter()
@@ -264,28 +272,23 @@ pub fn compute(
 
             let car_class_short_name = if car_screen_name_short.is_empty() {
                 NO_CLASS_LABEL.to_string()
+            } else if let Some(cached) = locked_state.cached_car_classes.get(&car_screen_name_short)
+            {
+                cached.clone()
             } else {
-                let mut locked_state = lock_or_recover(state);
+                let badge = get_compact_badge_name(&car_screen_name_short);
 
-                if let Some(cached) = locked_state.cached_car_classes.get(&car_screen_name_short) {
-                    let c: String = cached.clone();
-
-                    c
+                let result = if badge.is_empty() {
+                    NO_CLASS_LABEL.to_string()
                 } else {
-                    let badge = get_compact_badge_name(&car_screen_name_short);
+                    badge
+                };
 
-                    let result = if badge.is_empty() {
-                        NO_CLASS_LABEL.to_string()
-                    } else {
-                        badge
-                    };
+                locked_state
+                    .cached_car_classes
+                    .insert(car_screen_name_short.clone(), result.clone());
 
-                    locked_state
-                        .cached_car_classes
-                        .insert(car_screen_name_short.clone(), result.clone());
-
-                    result
-                }
+                result
             };
 
             DriverEntry {

--- a/src-tauri/src/computations/standings.rs
+++ b/src-tauri/src/computations/standings.rs
@@ -98,11 +98,11 @@ fn parse_class_color(raw_color: &Option<String>) -> String {
         None => NO_CLASS_COLOR.to_string(),
         Some(color) if color.is_empty() => NO_CLASS_COLOR.to_string(),
         Some(color) => {
-            let stripped = color
+            let trimmed = color.trim();
+            let stripped = trimmed
                 .strip_prefix("0x")
-                .or_else(|| color.strip_prefix("0X"))
-                .unwrap_or(color)
-                .trim()
+                .or_else(|| trimmed.strip_prefix("0X"))
+                .unwrap_or(trimmed)
                 .to_lowercase();
 
             // Map iRacing's mismatched telemetry class colors to their official in-game colors

--- a/src-tauri/src/computations/standings.rs
+++ b/src-tauri/src/computations/standings.rs
@@ -93,16 +93,30 @@ fn get_compact_badge_name(screen_name_short: &str) -> String {
     badge
 }
 
-fn parse_class_color(raw: &Option<String>) -> String {
-    match raw {
+fn parse_class_color(raw_color: &Option<String>) -> String {
+    match raw_color {
         None => NO_CLASS_COLOR.to_string(),
-        Some(s) if s.is_empty() => NO_CLASS_COLOR.to_string(),
-        Some(s) => {
-            let stripped = s
+        Some(color) if color.is_empty() => NO_CLASS_COLOR.to_string(),
+        Some(color) => {
+            let stripped = color
                 .strip_prefix("0x")
-                .or_else(|| s.strip_prefix("0X"))
-                .unwrap_or(s);
-            format!("#{stripped}")
+                .or_else(|| color.strip_prefix("0X"))
+                .unwrap_or(color)
+                .trim()
+                .to_lowercase();
+
+            // Map iRacing's mismatched telemetry class colors to their official in-game colors
+            let hex = match stripped.as_str() {
+                "53ff77" => "ff5888", // Mismatched Green -> Pink
+                "ae6bff" => "00c0ff", // Mismatched Purple -> Cyan
+                "d35400" => "ae6bff", // Mismatched Orange -> Purple
+                "ff5888" => "ef4444", // Mismatched Pink -> Soft Red
+                "ffd259" => "ffd259", // Yellow
+                "33ccff" => "33ccff", // Blue
+                other => other,
+            };
+
+            format!("#{hex}")
         }
     }
 }

--- a/src-tauri/src/computations/standings.rs
+++ b/src-tauri/src/computations/standings.rs
@@ -68,6 +68,7 @@ fn get_compact_badge_name(screen_name_short: &str) -> String {
     for &brand in BRANDS_TO_STRIP {
         if badge.starts_with(brand) {
             badge = badge[brand.len()..].to_string();
+
             break;
         }
     }
@@ -83,6 +84,7 @@ fn get_compact_badge_name(screen_name_short: &str) -> String {
             .chars()
             .filter(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
             .collect();
+
         if abbr.len() >= MIN_ABBR_LENGTH && abbr.len() <= MAX_ABBR_LENGTH {
             return abbr;
         }
@@ -189,6 +191,7 @@ pub fn compute(
     let mut seen_car_indices: std::collections::HashSet<i32> = std::collections::HashSet::new();
     let deduped_drivers: Vec<_> = {
         let mut result = Vec::new();
+
         // Pass 1: collect player entry (takes priority in dedup)
         for d in drivers.iter() {
             if d.car_idx == player_car_idx {
@@ -196,12 +199,14 @@ pub fn compute(
                 result.push(d);
             }
         }
+
         // Pass 2: collect first occurrence of each other car_idx
         for d in drivers.iter() {
             if seen_car_indices.insert(d.car_idx) {
                 result.push(d);
             }
         }
+
         result
     };
 
@@ -222,8 +227,8 @@ pub fn compute(
             let lap_pct = frame.car_idx_lap_dist_pct.get(idx).copied().unwrap_or(-1.0);
             pos > 0 || lap_pct >= 0.0
         })
-        .map(|d| {
-            let idx = d.car_idx as usize;
+        .map(|driver| {
+            let idx = driver.car_idx as usize;
 
             let tire_compound_idx = frame.car_idx_tire_compound.get(idx).copied().unwrap_or(-1);
             let tire_compound = if tire_compound_idx >= 0 {
@@ -236,39 +241,47 @@ pub fn compute(
                 String::new()
             };
 
-            let (start_overall, start_class) =
-                start_positions.get(&d.car_idx).copied().unwrap_or((0, 0));
+            let (start_overall, start_class) = start_positions
+                .get(&driver.car_idx)
+                .copied()
+                .unwrap_or((0, 0));
 
-            let car_screen_name_short = d.car_screen_name_short.clone().unwrap_or_default();
+            let car_screen_name_short = driver.car_screen_name_short.clone().unwrap_or_default();
+
             let car_class_short_name = if car_screen_name_short.is_empty() {
                 NO_CLASS_LABEL.to_string()
             } else {
                 let mut locked_state = lock_or_recover(state);
+
                 if let Some(cached) = locked_state.cached_car_classes.get(&car_screen_name_short) {
                     let c: String = cached.clone();
+
                     c
                 } else {
                     let badge = get_compact_badge_name(&car_screen_name_short);
+
                     let result = if badge.is_empty() {
                         NO_CLASS_LABEL.to_string()
                     } else {
                         badge
                     };
+
                     locked_state
                         .cached_car_classes
                         .insert(car_screen_name_short.clone(), result.clone());
+
                     result
                 }
             };
 
             DriverEntry {
-                car_idx: d.car_idx,
-                user_name: d.user_name.clone(),
-                car_number: d.car_number.clone().unwrap_or_default(),
-                car_class_id: d.car_class_id.unwrap_or(-1),
+                car_idx: driver.car_idx,
+                user_name: driver.user_name.clone(),
+                car_number: driver.car_number.clone().unwrap_or_default(),
+                car_class_id: driver.car_class_id.unwrap_or(-1),
                 car_class_short_name,
-                car_class_color: parse_class_color(&d.car_class_color),
-                car_screen_name: d.car_screen_name.clone().unwrap_or_default(),
+                car_class_color: parse_class_color(&driver.car_class_color),
+                car_screen_name: driver.car_screen_name.clone().unwrap_or_default(),
                 car_screen_name_short,
                 tire_compound,
                 position: frame.car_idx_position.get(idx).copied().unwrap_or(0),
@@ -292,15 +305,21 @@ pub fn compute(
                 track_surface: TrackSurface::from(
                     frame.car_idx_track_surface.get(idx).copied().unwrap_or(-1),
                 ),
-                i_rating: d.i_rating.unwrap_or(0),
-                lic_string: d.lic_string.clone().unwrap_or_else(|| "R 0.00".to_string()),
-                lic_color: d.lic_color.clone().unwrap_or_else(|| "000000".to_string()),
-                incidents: d.cur_driver_incident_count.unwrap_or(0),
-                is_player: d.car_idx == player_car_idx,
+                i_rating: driver.i_rating.unwrap_or(0),
+                lic_string: driver
+                    .lic_string
+                    .clone()
+                    .unwrap_or_else(|| "R 0.00".to_string()),
+                lic_color: driver
+                    .lic_color
+                    .clone()
+                    .unwrap_or_else(|| "000000".to_string()),
+                incidents: driver.cur_driver_incident_count.unwrap_or(0),
+                is_player: driver.car_idx == player_car_idx,
                 on_pit_road: frame.car_idx_on_pit_road.get(idx).copied().unwrap_or(false),
                 estimated_ir_delta: None,
                 relative_lap_dist: 0.0,
-                class_est_lap_time: d.car_class_est_lap_time.unwrap_or(0.0) as f32,
+                class_est_lap_time: driver.car_class_est_lap_time.unwrap_or(0.0) as f32,
             }
         })
         .collect();
@@ -323,17 +342,21 @@ pub fn compute(
 
     for entry in &mut entries {
         let mut diff = entry.lap_dist_pct - player_lap_dist;
+
         if diff < -0.5 {
             diff += 1.0;
         }
+
         if diff > 0.5 {
             diff -= 1.0;
         }
+
         entry.relative_lap_dist = diff;
     }
 
     if compute_ir_delta {
         let deltas = compute_ir_deltas(&entries);
+
         for entry in &mut entries {
             entry.estimated_ir_delta = deltas.get(&entry.car_idx).copied();
         }
@@ -348,7 +371,9 @@ pub fn compute(
 // Turbo87 iRating delta algorithm — port of iracing-irating.ts
 fn chance(a: f64, b: f64, factor: f64) -> f64 {
     let exp_a = (-a / factor).exp();
+
     let exp_b = (-b / factor).exp();
+
     ((1.0 - exp_a) * exp_b) / ((1.0 - exp_b) * exp_a + (1.0 - exp_a) * exp_b)
 }
 
@@ -359,6 +384,7 @@ fn compute_ir_deltas(entries: &[DriverEntry]) -> HashMap<i32, i32> {
 
     // Group by class
     let mut buckets: HashMap<i32, Vec<(i32, i32, i32)>> = HashMap::new(); // classId -> [(carIdx, classPos, iRating)]
+
     for e in entries {
         if e.i_rating <= 0 || e.class_position <= 0 {
             continue;
@@ -375,10 +401,12 @@ fn compute_ir_deltas(entries: &[DriverEntry]) -> HashMap<i32, i32> {
         }
 
         let n = bucket.len();
+
         let ir_ratings: Vec<f64> = bucket.iter().map(|&(_, _, ir)| ir as f64).collect();
 
         // Build chances matrix
         let mut chances: Vec<Vec<f64>> = vec![vec![0.0; n]; n];
+
         for i in 0..n {
             for j in 0..n {
                 chances[i][j] = chance(ir_ratings[i], ir_ratings[j], br1);
@@ -437,14 +465,17 @@ pub fn parse_start_positions(results: &[serde_yaml_ng::Value]) -> HashMap<i32, (
     }
 
     let mut map = HashMap::new();
+
     for val in results {
         if let Ok(rp) = serde_yaml_ng::from_value::<ResultPos>(val.clone()) {
             if let (Some(idx), Some(pos)) = (rp.car_idx, rp.position) {
                 // Position is 1-indexed in iRacing YAML; ClassPosition is 0-indexed.
                 let class_pos = rp.class_position.unwrap_or(pos - 1);
+
                 map.insert(idx, (pos, class_pos + 1));
             }
         }
     }
+
     map
 }

--- a/src-tauri/src/iracing/mod.rs
+++ b/src-tauri/src/iracing/mod.rs
@@ -43,10 +43,12 @@ pub use frames::{
     CarDynamicsFrame, CarIdxFrame, CarInputsFrame, CarStatusFrame, ChassisFrame, EnvironmentFrame,
     LapTimingFrame, SessionFrame,
 };
+
 pub use service::{
     get_last_session_info, set_active_events, set_car_length, set_pit_warning_laps,
     start_telemetry_stream, stop_telemetry_stream, ComputationState, TelemetryServiceState,
     TelemetryState,
 };
+
 #[allow(unused_imports)]
 pub use weather_forecast::WeatherForecastEntry;

--- a/src-tauri/src/iracing/service.rs
+++ b/src-tauri/src/iracing/service.rs
@@ -134,7 +134,9 @@ pub async fn set_pit_warning_laps(
 #[tauri::command]
 pub async fn set_active_events(state: State<'_, TelemetryState>, mask: u32) -> Result<(), String> {
     state.service.active_events.store(mask, Ordering::Relaxed);
+
     debug!("Active events mask updated to: {:#b}", mask);
+
     Ok(())
 }
 
@@ -145,6 +147,7 @@ pub async fn set_car_length(state: State<'_, TelemetryState>, length: f32) -> Re
     }
 
     let mut lock = lock_or_recover(&state.service.car_length_m);
+
     *lock = length;
     debug!("Car length updated in backend to: {}m", length);
 
@@ -157,13 +160,16 @@ pub async fn start_telemetry_stream(
     state: State<'_, TelemetryState>,
 ) -> Result<(), String> {
     info!("start_telemetry_stream command received");
+
     state.service.running.store(false, Ordering::SeqCst);
+
     sleep(Duration::from_millis(50)).await;
 
     state.service.running.store(true, Ordering::SeqCst);
 
     let service = state.service.clone();
     let pit = state.pit.clone();
+
     let computation = state.computation.clone();
     let app_clone = app.clone();
 
@@ -207,6 +213,7 @@ pub async fn start_telemetry_stream(
             run_telemetry_loop(&app_clone, stream.as_mut(), &service, &pit, &computation).await;
 
             session_task.abort();
+
             info!("Stream ended, will retry connection...");
             reset_telemetry_state(&app_clone, &service, &pit, &computation);
 
@@ -240,8 +247,10 @@ fn spawn_session_polling(
     service: Arc<TelemetryServiceState>,
 ) -> tokio::task::JoinHandle<()> {
     debug!("Spawning session polling task...");
+
     tokio::spawn(async move {
         debug!("Session polling task spawned and running");
+
         let mut last_version = -1;
         // Since Pitwall::connect() succeeded, we know shared memory is accessible.
         // We create a direct WindowsConnection for robust session info polling
@@ -257,6 +266,7 @@ fn spawn_session_polling(
         loop {
             if !service.running.load(Ordering::SeqCst) {
                 debug!("Session polling task: Stopping (service inactive)");
+
                 break;
             }
 
@@ -278,12 +288,14 @@ fn spawn_session_polling(
                             "Session polling task: Fetched raw YAML ({} bytes)",
                             raw_yaml.len()
                         );
+
                         match pitwall::preprocess_iracing_yaml(&raw_yaml) {
                             Ok(preprocessed) => {
                                 debug!(
                                     "Session polling task: YAML preprocessed ({} bytes)",
                                     preprocessed.len()
                                 );
+
                                 match serde_yaml_ng::from_str::<SessionInfo>(&preprocessed) {
                                     Ok(session) => {
                                         info!(
@@ -380,6 +392,7 @@ async fn run_telemetry_loop<S>(
     loop {
         if !service.running.load(Ordering::SeqCst) {
             debug!("Stream stopped by user");
+
             return;
         }
 
@@ -457,7 +470,9 @@ fn reset_telemetry_state(
 #[tauri::command]
 pub async fn stop_telemetry_stream(state: State<'_, TelemetryState>) -> Result<(), String> {
     state.service.running.store(false, Ordering::SeqCst);
+
     debug!("Telemetry stream stopped");
+
     Ok(())
 }
 
@@ -484,12 +499,15 @@ fn yaml_to_json(val: serde_yaml_ng::Value) -> JsonValue {
                 JsonValue::Null
             }
         }
+
         serde_yaml_ng::Value::String(s) => JsonValue::String(s),
         serde_yaml_ng::Value::Sequence(seq) => {
             JsonValue::Array(seq.into_iter().map(yaml_to_json).collect())
         }
+
         serde_yaml_ng::Value::Mapping(map) => {
             let mut obj = serde_json::Map::new();
+
             for (k, v) in map {
                 if let Some(key) = k.as_str() {
                     obj.insert(key.to_string(), yaml_to_json(v));
@@ -532,6 +550,7 @@ fn update_start_positions(
     start_positions: &Mutex<HashMap<i32, (i32, i32)>>,
 ) {
     let current_num = session.session_info.current_session_num as usize;
+
     let results = session
         .session_info
         .sessions
@@ -542,7 +561,9 @@ fn update_start_positions(
         if results.is_empty() {
             return;
         }
+
         let new_positions = standings::parse_start_positions(results);
+
         if !new_positions.is_empty() {
             if let Ok(mut lock) = start_positions.lock() {
                 *lock = new_positions;
@@ -641,9 +662,11 @@ fn emit_domain_frames(ctx: EmitContext<'_>) {
         if let Some(session) = session_info {
             let track_length = lock_or_recover(&ctx.service.track_length_m).unwrap_or(0.0);
             let car_length = *lock_or_recover(&ctx.service.car_length_m);
+
             bundle.proximity = Some(proximity::compute(frame, session, track_length, car_length));
 
             let start_pos_snapshot = lock_or_recover(&ctx.service.start_positions).clone();
+
             bundle.standings = Some(standings::compute(
                 frame,
                 session,
@@ -665,8 +688,10 @@ fn emit_domain_frames(ctx: EmitContext<'_>) {
 
             {
                 let mut state = lock_or_recover(&ctx.computation.fuel);
+
                 let current_lap = frame.lap.unwrap_or(-1);
                 let session_num = frame.session_num.unwrap_or(-1);
+
                 state.update(current_lap, frame.fuel_level, session_num);
             }
 

--- a/src-tauri/src/iracing/weather_forecast.rs
+++ b/src-tauri/src/iracing/weather_forecast.rs
@@ -43,6 +43,7 @@ pub fn parse_weather_forecast(
     ) -> Option<&'a serde_yaml_ng::Value> {
         if let Some(map) = value.as_mapping() {
             let target_lower = target.to_lowercase();
+
             for (k, v) in map {
                 if let Some(k_str) = k.as_str() {
                     if k_str.to_lowercase() == target_lower {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,16 +10,19 @@ use computations::{
     proximity::{LateralSide, NearbyCar, ProximityFrame, RadarDistances},
     standings::{DriverEntriesFrame, DriverEntry},
 };
+
 use computations::{fuel::FuelState, lap_delta::LapDeltaState, standings::StandingsState};
 use iracing::{
     get_last_session_info, set_active_events, set_car_length, set_pit_warning_laps,
     start_telemetry_stream, stop_telemetry_stream, TelemetryState,
 };
+
 #[cfg(feature = "dev")]
 use iracing::{
     CarDynamicsFrame, CarIdxFrame, CarInputsFrame, CarStatusFrame, ChassisFrame, EnvironmentFrame,
     LapTimingFrame, SessionFrame, WeatherForecastEntry,
 };
+
 #[cfg(feature = "dev")]
 use pitwall::SessionInfo;
 #[cfg(feature = "dev")]

--- a/src/app/main/components/WidgetSettings/panels/RelativeSettingsPanel.tsx
+++ b/src/app/main/components/WidgetSettings/panels/RelativeSettingsPanel.tsx
@@ -34,12 +34,6 @@ export const RelativeSettingsPanel = observer(() => {
           onChange: (v: boolean) => update({ showIRatingBadge: v }),
         },
         {
-          title: 'Trend Icon',
-          desc: 'Show arrow indicating if gap is closing or opening.',
-          value: settings.showTrendIcon,
-          onChange: (v: boolean) => update({ showTrendIcon: v }),
-        },
-        {
           title: 'Pit Indicator',
           desc: 'Show icon when driver is in pits.',
           value: settings.showPitIndicator,

--- a/src/components/shared/ClassBadge/ClassBadge.module.scss
+++ b/src/components/shared/ClassBadge/ClassBadge.module.scss
@@ -4,7 +4,7 @@
   justify-content: center;
   padding: 0.2em 0.25em;
   border-radius: 0.25em;
-  color: black;
+  color: contrast-color(var(--badge-bg, #fff));
   font-size: 0.85em;
   font-weight: 700;
   line-height: 1;

--- a/src/components/shared/ClassBadge/ClassBadge.tsx
+++ b/src/components/shared/ClassBadge/ClassBadge.tsx
@@ -12,7 +12,7 @@ export const ClassBadge = ({ color, label, className }: ClassBadgeProps) => {
   return (
     <span
       className={`${styles.classBadge}${className ? ` ${className}` : ''}`}
-      style={{ backgroundColor: color }}
+      style={{ backgroundColor: color, ['--badge-bg' as string]: color }}
     >
       {label}
     </span>

--- a/src/store/widget-defaults.ts
+++ b/src/store/widget-defaults.ts
@@ -294,7 +294,6 @@ export const WIDGETS: WidgetConfig[] = [
       showClassBadge: true,
       showPitIndicator: true,
       abbreviateNames: true,
-      showTrendIcon: true,
     },
   },
   {

--- a/src/types/widget-settings.ts
+++ b/src/types/widget-settings.ts
@@ -68,7 +68,6 @@ export interface RelativeWidgetSettings {
   showIRatingBadge: boolean;
   showClassBadge: boolean;
   showPitIndicator: boolean;
-  showTrendIcon: boolean;
   abbreviateNames: boolean;
 }
 

--- a/src/utils/widget/standings-utils.ts
+++ b/src/utils/widget/standings-utils.ts
@@ -49,8 +49,8 @@ const buildColDefs = (settings: StandingsWidgetSettings): ColDef[] => [
   { width: ws(20), show: true }, // pos      "00"
   { width: ws(40), show: true }, // carNum   "#000"
   { width: `minmax(${ws(100)}, 1fr)`, show: true }, // name     — never collapses
-  { width: ws(30), show: settings.showBrand }, // brand
-  { width: ws(16), show: settings.showTire }, // tire
+  { width: ws(32), show: settings.showBrand }, // brand
+  { width: ws(18), show: settings.showTire }, // tire
   {
     width: ws(48),
     show: !settings.enableClassCycling && settings.showClassBadge,

--- a/src/utils/widget/widget-utils.ts
+++ b/src/utils/widget/widget-utils.ts
@@ -9,10 +9,6 @@ export const TRACK_SURFACE_IN_PIT_STALL: TrackSurfaceType =
 export const TRACK_SURFACE_ON_TRACK: TrackSurfaceType = TrackSurface.OnTrack;
 export const NEAR_DQ_INCIDENT_THRESHOLD = 15;
 
-// ─── Trend sampling ───────────────────────────────────────────────────────
-
-export const TREND_SAMPLE_INTERVAL_MS = 2000;
-
 // ─── Formatters ───────────────────────────────────────────────────────────
 
 export const formatIRating = (ir: number): string => {

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
@@ -112,17 +112,10 @@
 
 // F2 Time (gap) block
 .f2Block {
-  display: grid;
-  grid-template-columns: ws(15) 1fr;
+  display: flex;
+  justify-content: flex-end;
   align-items: center;
   padding-right: ws(2);
-}
-
-.trendSlot {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: ws(15);
 }
 
 .f2Time {
@@ -142,15 +135,4 @@
 
 .f2Player {
   color: $widget-status-caution;
-}
-
-// Trend arrows
-.trendUp {
-  color: $widget-status-positive;
-  flex-shrink: 0;
-}
-
-.trendDown {
-  color: $widget-status-danger;
-  flex-shrink: 0;
 }

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
@@ -1,6 +1,4 @@
-﻿import React from 'react';
 import { observer } from 'mobx-react-lite';
-import { ChevronUp, ChevronDown } from 'lucide-react';
 import {
   abbreviateName,
   TRACK_SURFACE_IN_PIT_STALL,
@@ -20,17 +18,17 @@ import {
 
 interface DriverRowProps {
   driver: DriverEntry;
-  trendDelta: number;
 }
 
-export const DriverRow = observer(({ driver, trendDelta }: DriverRowProps) => {
-  const computed = useBackendComputedStore();
+export const DriverRow = observer(({ driver }: DriverRowProps) => {
+  const { relativeEntries } = useBackendComputedStore();
   const widgetSettings = useWidgetSettingsStore();
 
   const settings =
     widgetSettings.getSettings<RelativeWidgetSettings>('relative');
-  const player =
-    computed.relativeEntries.find((entry) => entry.isPlayer) ?? null;
+
+  const player = relativeEntries.find((entry) => entry.isPlayer) ?? null;
+
   const isPit =
     driver.trackSurface === TRACK_SURFACE_IN_PIT_STALL || driver.onPitRoad;
 
@@ -59,21 +57,6 @@ export const DriverRow = observer(({ driver, trendDelta }: DriverRowProps) => {
         ? styles.f2Negative
         : styles.f2Player;
 
-  let trendIcon: React.ReactNode = null;
-
-  if (
-    settings.showTrendIcon &&
-    !driver.isPlayer &&
-    Math.abs(trendDelta) > 0.00005
-  ) {
-    trendIcon =
-      trendDelta < 0 ? (
-        <ChevronUp size={16} className={styles.trendUp} />
-      ) : (
-        <ChevronDown size={16} className={styles.trendDown} />
-      );
-  }
-
   const rowClass = [
     styles.driverRow,
     driver.isPlayer ? styles.driverRowPlayer : '',
@@ -88,7 +71,7 @@ export const DriverRow = observer(({ driver, trendDelta }: DriverRowProps) => {
         <span
           className={`${styles.driverPosition} ${driver.isPlayer ? styles.driverPositionPlayer : ''}`}
         >
-          {driver.position}
+          {driver.classPosition || driver.position}
         </span>
       </div>
 
@@ -148,7 +131,6 @@ export const DriverRow = observer(({ driver, trendDelta }: DriverRowProps) => {
       </div>
 
       <div className={styles.f2Block}>
-        <span className={styles.trendSlot}>{trendIcon}</span>
         <span className={`${styles.f2Time} ${f2Class}`}>
           {driver.isPlayer ? '-' : f2TimeStr}
         </span>

--- a/src/widgets/RelativeWidget/RelativeContent/RelativeContent.tsx
+++ b/src/widgets/RelativeWidget/RelativeContent/RelativeContent.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 
 import { useVisibleRowCount } from '@hooks/common/useVisibleRowCount';
 import { DriverRow } from '@widgets/RelativeWidget/DriverRow/DriverRow';
-import { computeRelativeGap } from '@utils/widget/relative-utils';
-import { TREND_SAMPLE_INTERVAL_MS } from '@utils/widget/widget-utils';
 
 import styles from './RelativeContent.module.scss';
 import { useBackendComputedStore } from '@store/root-store-context';
@@ -14,61 +12,8 @@ export const RelativeContent = observer(() => {
 
   const entries = computed.relativeEntries;
 
-  const prevGapTimesRef = useRef<Map<number, number>>(new Map());
-  const lastSnapshotTimeRef = useRef<number>(0);
-
   const { ref: driverListRef, count: visibleRowCount } =
     useVisibleRowCount<HTMLDivElement>(2.75, 3, '[data-relative-row]');
-
-  const [trendMap, setTrendMap] = useState<Map<number, number>>(new Map());
-
-  useEffect(() => {
-    const now = Date.now();
-
-    if (now - lastSnapshotTimeRef.current < TREND_SAMPLE_INTERVAL_MS) {
-      return;
-    }
-
-    const prevSnapshot = prevGapTimesRef.current;
-    const newTrends = new Map<number, number>();
-    const playerEntry = entries.find((entry) => entry.isPlayer);
-
-    if (playerEntry) {
-      for (const entry of entries) {
-        if (entry.isPlayer) {
-          continue;
-        }
-
-        const prevGap = prevSnapshot.get(entry.carIdx);
-        const currGap = computeRelativeGap(entry, playerEntry);
-
-        if (prevGap === undefined) {
-          continue;
-        }
-
-        const gapDelta = currGap - prevGap;
-
-        if (Math.abs(gapDelta) > 0.01) {
-          newTrends.set(entry.carIdx, gapDelta);
-        }
-      }
-    }
-
-    setTrendMap(newTrends);
-
-    const newTimes = new Map<number, number>();
-
-    for (const entry of entries) {
-      if (entry.isPlayer || !playerEntry) {
-        continue;
-      }
-
-      newTimes.set(entry.carIdx, computeRelativeGap(entry, playerEntry));
-    }
-
-    prevGapTimesRef.current = newTimes;
-    lastSnapshotTimeRef.current = now;
-  }, [entries]);
 
   const displayEntries = useMemo(() => {
     const playerIdx = entries.findIndex((entry) => entry.isPlayer);
@@ -79,10 +24,13 @@ export const RelativeContent = observer(() => {
 
     const total = Math.min(visibleRowCount, entries.length);
     const half = Math.floor(total / 2);
+
     const aboveAvail = playerIdx;
     const belowAvail = entries.length - playerIdx - 1;
+
     let above = Math.min(half, aboveAvail);
     const below = Math.min(total - 1 - above, belowAvail);
+
     above = Math.min(total - 1 - below, aboveAvail);
 
     return entries.slice(playerIdx - above, playerIdx + below + 1);
@@ -91,11 +39,7 @@ export const RelativeContent = observer(() => {
   return (
     <div ref={driverListRef} className={styles.driverList}>
       {displayEntries.map((entry) => (
-        <DriverRow
-          key={entry.carIdx}
-          driver={entry}
-          trendDelta={trendMap.get(entry.carIdx) ?? 0}
-        />
+        <DriverRow key={entry.carIdx} driver={entry} />
       ))}
     </div>
   );

--- a/src/widgets/RelativeWidget/RelativeWidget.stories.tsx
+++ b/src/widgets/RelativeWidget/RelativeWidget.stories.tsx
@@ -29,7 +29,6 @@ const DEFAULT_SETTINGS: RelativeWidgetSettings = {
   showIRatingBadge: false,
   showClassBadge: false,
   showPitIndicator: true,
-  showTrendIcon: true,
   abbreviateNames: false,
 };
 
@@ -85,7 +84,6 @@ export const MinimalView: Story = {
       showIRatingBadge: false,
       showClassBadge: false,
       showPitIndicator: false,
-      showTrendIcon: false,
     },
   },
 };

--- a/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.module.scss
+++ b/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.module.scss
@@ -1,7 +1,7 @@
 .headerRow {
   display: grid;
   align-items: center;
-  column-gap: ws(6);
+  column-gap: ws(2);
   padding: ws(5) ws(10);
   background: rgb(24, 24, 27);
   border-bottom: 1px solid rgba(39, 39, 42, 0.5);

--- a/src/widgets/StandingsWidget/StandingsHeader/StandingsHeaderCell.module.scss
+++ b/src/widgets/StandingsWidget/StandingsHeader/StandingsHeaderCell.module.scss
@@ -4,7 +4,7 @@
   font-size: ws(9);
   letter-spacing: 0.06em;
   color: $widget-text-secondary;
-  font-weight: 600;
+  font-weight: 300;
   white-space: nowrap;
   overflow: hidden;
 }

--- a/src/widgets/StandingsWidget/StandingsHeader/StandingsHeaderCell.tsx
+++ b/src/widgets/StandingsWidget/StandingsHeader/StandingsHeaderCell.tsx
@@ -6,11 +6,17 @@ import styles from './StandingsHeaderCell.module.scss';
 interface StandingsHeaderCellProps {
   align?: 'left' | 'center' | 'right';
   title?: string;
+  className?: string;
   children: React.ReactNode;
 }
 
 export const StandingsHeaderCell = observer(
-  ({ align = 'left', title, children }: StandingsHeaderCellProps) => {
+  ({
+    align = 'left',
+    title,
+    className,
+    children,
+  }: StandingsHeaderCellProps) => {
     const alignClass =
       align === 'center'
         ? styles.thCenter
@@ -20,7 +26,7 @@ export const StandingsHeaderCell = observer(
 
     return (
       <span
-        className={`${styles.th}${alignClass ? ` ${alignClass}` : ''}`}
+        className={[styles.th, alignClass, className].filter(Boolean).join(' ')}
         title={title}
       >
         {children}


### PR DESCRIPTION
- Relative widget — removed the trend icon (chevron up/down) and the entire gap trend tracking mechanism. The position now displays classPosition instead of absolute position.
- Class colors — fixed mapping of class colors from iRacing telemetry to official game colors (6 pairs)
- ClassBadge — adaptive text color using contrast-color() instead of hardcoded.
- Standings — minor visual fixes: indents, horizontal spaces in the title.

Closed #181 
Closed #171