### PR TITLE
fix(track-map): preserve track shape on widget remount after hide-all toggle

### DIFF
--- a/src/store/widgets/track-map.widget.ts
+++ b/src/store/widgets/track-map.widget.ts
@@ -7,6 +7,7 @@ export class TrackMapWidgetStore {
   isWaitingForSF = false;
   recordingProgress = 0;
   trackShape: TrackShapePayload | null = null;
+  currentTrackId: string | null = null;
 
   constructor() {
     makeAutoObservable(this, {}, { autoBind: true });
@@ -24,6 +25,7 @@ export class TrackMapWidgetStore {
 
   onTrackShapeReceived(payload: TrackShapePayload) {
     this.trackShape = payload;
+    this.currentTrackId = String(payload.trackId);
     this.isRecording = false;
     this.isWaitingForSF = false;
     this.recordingProgress = 1;
@@ -31,6 +33,7 @@ export class TrackMapWidgetStore {
 
   clearTrackShape() {
     this.trackShape = null;
+    this.currentTrackId = null;
     this.isRecording = false;
     this.isWaitingForSF = false;
     this.recordingProgress = 0;
@@ -41,5 +44,6 @@ export class TrackMapWidgetStore {
     this.isWaitingForSF = false;
     this.recordingProgress = 0;
     this.trackShape = null;
+    this.currentTrackId = null;
   }
 }

--- a/src/widgets/TrackMapWidget/TrackMapContent/TrackMapContent.tsx
+++ b/src/widgets/TrackMapWidget/TrackMapContent/TrackMapContent.tsx
@@ -78,8 +78,12 @@ export const TrackMapContent = observer(() => {
   useEffect(() => {
     if (!trackId) return;
 
-    savedRotationRef.current = 0;
-    trackMapWidget.clearTrackShape();
+    const trackChanged = trackMapWidget.currentTrackId !== trackId;
+
+    if (trackChanged) {
+      savedRotationRef.current = 0;
+      trackMapWidget.clearTrackShape();
+    }
 
     const loadRotation = async () => {
       try {


### PR DESCRIPTION
clearTrackShape was called unconditionally on every effect run, including widget remounts caused by hideAllWidgets (F10). Now it only clears when the session track actually changes, identified by tracking currentTrackId in TrackMapWidgetStore