### PR TITLE
feat(overlay): add drag toolbar with quick snap and widget settings popup

### DIFF
--- a/src/app/overlay/components/WidgetContainer/WidgetContainer.module.scss
+++ b/src/app/overlay/components/WidgetContainer/WidgetContainer.module.scss
@@ -45,25 +45,6 @@
   }
 }
 
-.dragOverlay {
-  position: absolute;
-  top: $space-xs;
-  right: $space-xs;
-  z-index: 1000;
-  pointer-events: none;
-}
-
-.dragLabel {
-  font-family: $font-mono;
-  font-size: rem(10);
-  color: $widget-surface-base;
-  background: $widget-text-accent;
-  padding: rem(2) rem(6);
-  border-radius: 2px;
-  font-weight: bold;
-  letter-spacing: 0.5px;
-}
-
 // ── Resize handles ───────────────────────────────────────────
 
 $handle-corner: rem(14);

--- a/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react-lite';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import styles from './WidgetContainer.module.scss';
 import { WidgetIdContext } from './WidgetIdContext';
+import { WidgetDragToolbar } from '@app/overlay/components/WidgetDragToolbar/WidgetDragToolbar';
 import {
   useAppSettingsStore,
   useSimStore,
@@ -242,11 +243,7 @@ export const WidgetContainer = observer(
             </div>
           </ErrorBoundary>
 
-          {dragMode && (
-            <div className={styles.dragOverlay}>
-              <span className={styles.dragLabel}>DRAG MODE</span>
-            </div>
-          )}
+          {dragMode && <WidgetDragToolbar widgetId={widgetId} />}
 
           {dragMode &&
             resizeDirections.map((direction) => (

--- a/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.module.scss
+++ b/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.module.scss
@@ -1,0 +1,43 @@
+.snapPanel {
+  position: fixed;
+  display: grid;
+  grid-template-columns: repeat(3, 28px);
+  grid-template-rows: repeat(3, 28px);
+  gap: 3px;
+  padding: 6px;
+  background: rgba(13, 14, 18, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.6);
+  z-index: 99999;
+}
+
+.snapButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.12s ease;
+
+  &:hover {
+    background: rgba($widget-text-accent, 0.15);
+    border-color: $widget-text-accent;
+    color: $widget-text-accent;
+  }
+
+  &:active {
+    transform: scale(0.9);
+  }
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+}

--- a/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.tsx
+++ b/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.tsx
@@ -55,6 +55,8 @@ export const SnapPanel = observer(({ widgetId, onClose }: SnapPanelProps) => {
   const widgetSettings = useWidgetSettingsStore();
   const panelRef = useClickOutside<HTMLDivElement>(onClose);
 
+  const widget = widgetSettings.getWidget(widgetId);
+
   if (!widget) {
     return null;
   }
@@ -69,10 +71,6 @@ export const SnapPanel = observer(({ widgetId, onClose }: SnapPanelProps) => {
   const clampedTop = Math.min(panelTop, screenH - 120 - SNAP_MARGIN);
 
   const snapTo = (pos: SnapPosition) => {
-    if (!widget) {
-      return;
-    }
-
     const width = widget.userSettings.currentWidth;
     const height = widget.userSettings.currentHeight;
     const screenW = window.innerWidth;

--- a/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.tsx
+++ b/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom';
 import { observer } from 'mobx-react-lite';
+import { useClickOutside } from '@hooks/common/useClickOutside';
 import {
   ArrowDownLeft,
   ArrowDown,
@@ -52,11 +53,15 @@ interface SnapPanelProps {
 
 export const SnapPanel = observer(({ widgetId, onClose }: SnapPanelProps) => {
   const widgetSettings = useWidgetSettingsStore();
+  const panelRef = useClickOutside<HTMLDivElement>(onClose);
 
-  const widget = widgetSettings.getWidget(widgetId);
-  const widgetX = widget?.userSettings.x ?? 0;
-  const widgetY = widget?.userSettings.y ?? 0;
-  const widgetW = widget?.userSettings.currentWidth ?? 200;
+  if (!widget) {
+    return null;
+  }
+
+  const widgetX = widget.userSettings.x;
+  const widgetY = widget.userSettings.y;
+  const widgetW = widget.userSettings.currentWidth;
   const screenH = window.innerHeight;
 
   const panelLeft = widgetX + widgetW - PANEL_WIDTH - 4;
@@ -102,6 +107,7 @@ export const SnapPanel = observer(({ widgetId, onClose }: SnapPanelProps) => {
 
   return ReactDOM.createPortal(
     <div
+      ref={panelRef}
       role="menu"
       tabIndex={-1}
       className={styles.snapPanel}

--- a/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.tsx
+++ b/src/app/overlay/components/WidgetDragToolbar/SnapPanel/SnapPanel.tsx
@@ -1,0 +1,128 @@
+import ReactDOM from 'react-dom';
+import { observer } from 'mobx-react-lite';
+import {
+  ArrowDownLeft,
+  ArrowDown,
+  ArrowDownRight,
+  ArrowLeft,
+  Maximize2,
+  ArrowRight,
+  ArrowUpLeft,
+  ArrowUp,
+  ArrowUpRight,
+} from 'lucide-react';
+import styles from './SnapPanel.module.scss';
+import { useWidgetSettingsStore } from '@store/root-store-context';
+
+const SNAP_MARGIN = 8;
+const PANEL_WIDTH = 102;
+const TOOLBAR_OFFSET_TOP = 30;
+
+type SnapPosition =
+  | 'topLeft'
+  | 'topCenter'
+  | 'topRight'
+  | 'midLeft'
+  | 'center'
+  | 'midRight'
+  | 'bottomLeft'
+  | 'bottomCenter'
+  | 'bottomRight';
+
+const SNAP_BUTTONS: Array<{
+  pos: SnapPosition;
+  icon: React.ReactNode;
+  title: string;
+}> = [
+  { pos: 'topLeft', icon: <ArrowUpLeft />, title: 'Top Left' },
+  { pos: 'topCenter', icon: <ArrowUp />, title: 'Top Center' },
+  { pos: 'topRight', icon: <ArrowUpRight />, title: 'Top Right' },
+  { pos: 'midLeft', icon: <ArrowLeft />, title: 'Middle Left' },
+  { pos: 'center', icon: <Maximize2 />, title: 'Center' },
+  { pos: 'midRight', icon: <ArrowRight />, title: 'Middle Right' },
+  { pos: 'bottomLeft', icon: <ArrowDownLeft />, title: 'Bottom Left' },
+  { pos: 'bottomCenter', icon: <ArrowDown />, title: 'Bottom Center' },
+  { pos: 'bottomRight', icon: <ArrowDownRight />, title: 'Bottom Right' },
+];
+
+interface SnapPanelProps {
+  widgetId: string;
+  onClose: () => void;
+}
+
+export const SnapPanel = observer(({ widgetId, onClose }: SnapPanelProps) => {
+  const widgetSettings = useWidgetSettingsStore();
+
+  const widget = widgetSettings.getWidget(widgetId);
+  const widgetX = widget?.userSettings.x ?? 0;
+  const widgetY = widget?.userSettings.y ?? 0;
+  const widgetW = widget?.userSettings.currentWidth ?? 200;
+  const screenH = window.innerHeight;
+
+  const panelLeft = widgetX + widgetW - PANEL_WIDTH - 4;
+  const panelTop = widgetY + TOOLBAR_OFFSET_TOP;
+  const clampedTop = Math.min(panelTop, screenH - 120 - SNAP_MARGIN);
+
+  const snapTo = (pos: SnapPosition) => {
+    if (!widget) {
+      return;
+    }
+
+    const width = widget.userSettings.currentWidth;
+    const height = widget.userSettings.currentHeight;
+    const screenW = window.innerWidth;
+    const m = SNAP_MARGIN;
+
+    const positions: Record<SnapPosition, { x: number; y: number }> = {
+      topLeft: { x: m, y: m },
+      topCenter: { x: Math.round((screenW - width) / 2), y: m },
+      topRight: { x: screenW - width - m, y: m },
+      midLeft: { x: m, y: Math.round((screenH - height) / 2) },
+      center: {
+        x: Math.round((screenW - width) / 2),
+        y: Math.round((screenH - height) / 2),
+      },
+      midRight: {
+        x: screenW - width - m,
+        y: Math.round((screenH - height) / 2),
+      },
+      bottomLeft: { x: m, y: screenH - height - m },
+      bottomCenter: {
+        x: Math.round((screenW - width) / 2),
+        y: screenH - height - m,
+      },
+      bottomRight: { x: screenW - width - m, y: screenH - height - m },
+    };
+
+    const { x, y } = positions[pos];
+
+    widgetSettings.updatePosition(widgetId, x, y);
+    onClose();
+  };
+
+  return ReactDOM.createPortal(
+    <div
+      role="menu"
+      tabIndex={-1}
+      className={styles.snapPanel}
+      style={{ left: panelLeft, top: clampedTop }}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      {SNAP_BUTTONS.map(({ pos, icon, title }) => (
+        <button
+          key={pos}
+          type="button"
+          className={styles.snapButton}
+          title={title}
+          onClick={(e) => {
+            e.stopPropagation();
+            snapTo(pos);
+          }}
+        >
+          {icon}
+        </button>
+      ))}
+    </div>,
+    document.body
+  );
+});

--- a/src/app/overlay/components/WidgetDragToolbar/WidgetDragToolbar.module.scss
+++ b/src/app/overlay/components/WidgetDragToolbar/WidgetDragToolbar.module.scss
@@ -1,0 +1,69 @@
+.toolbar {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.dragLabel {
+  font-family: $font-mono;
+  font-size: 9px;
+  color: #000;
+  background: $widget-text-accent;
+  padding: 2px 5px;
+  border-radius: 3px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  line-height: 1;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+}
+
+.buttons {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  position: relative;
+}
+
+.toolbarButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  background: rgba(0, 0, 0, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.12s ease;
+  pointer-events: auto;
+
+  &:hover {
+    background: rgba($widget-text-accent, 0.85);
+    color: #000;
+    border-color: transparent;
+  }
+
+  &:active {
+    transform: scale(0.92);
+  }
+
+  &.active {
+    background: $widget-text-accent;
+    color: #000;
+    border-color: transparent;
+  }
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+}

--- a/src/app/overlay/components/WidgetDragToolbar/WidgetDragToolbar.tsx
+++ b/src/app/overlay/components/WidgetDragToolbar/WidgetDragToolbar.tsx
@@ -1,0 +1,88 @@
+import { useState, useEffect } from 'react';
+import { observer } from 'mobx-react-lite';
+import { LayoutGrid, Settings2 } from 'lucide-react';
+import styles from './WidgetDragToolbar.module.scss';
+import { SnapPanel } from './SnapPanel/SnapPanel';
+import { WidgetSettingsPopup } from './WidgetSettingsPopup/WidgetSettingsPopup';
+
+interface WidgetDragToolbarProps {
+  widgetId: string;
+}
+
+export const WidgetDragToolbar = observer(
+  ({ widgetId }: WidgetDragToolbarProps) => {
+    const [snapOpen, setSnapOpen] = useState(false);
+    const [settingsOpen, setSettingsOpen] = useState(false);
+
+    useEffect(() => {
+      if (!snapOpen && !settingsOpen) {
+        return;
+      }
+
+      const onKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          setSnapOpen(false);
+          setSettingsOpen(false);
+        }
+      };
+
+      document.addEventListener('keydown', onKey);
+
+      return () => document.removeEventListener('keydown', onKey);
+    }, [snapOpen, settingsOpen]);
+
+    const toggleSnap = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setSnapOpen((prev) => !prev);
+      setSettingsOpen(false);
+    };
+
+    const toggleSettings = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      setSettingsOpen((prev) => !prev);
+      setSnapOpen(false);
+    };
+
+    return (
+      <div
+        role="toolbar"
+        tabIndex={-1}
+        className={styles.toolbar}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <span className={styles.dragLabel}>DRAG</span>
+
+        <div className={styles.buttons}>
+          <button
+            type="button"
+            className={`${styles.toolbarButton} ${snapOpen ? styles.active : ''}`}
+            title="Quick placement"
+            onClick={toggleSnap}
+          >
+            <LayoutGrid />
+          </button>
+
+          <button
+            type="button"
+            className={`${styles.toolbarButton} ${settingsOpen ? styles.active : ''}`}
+            title="Widget settings"
+            onClick={toggleSettings}
+          >
+            <Settings2 />
+          </button>
+        </div>
+
+        {snapOpen && (
+          <SnapPanel widgetId={widgetId} onClose={() => setSnapOpen(false)} />
+        )}
+
+        {settingsOpen && (
+          <WidgetSettingsPopup
+            widgetId={widgetId}
+            onClose={() => setSettingsOpen(false)}
+          />
+        )}
+      </div>
+    );
+  }
+);

--- a/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.module.scss
+++ b/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.module.scss
@@ -1,0 +1,167 @@
+.popup {
+  // Reset <dialog> browser defaults
+  margin: 0;
+  padding: 0;
+  color: inherit;
+
+  position: fixed;
+  z-index: 9999;
+  background: #0d0e12;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.7);
+  max-height: 560px;
+  display: flex;
+  flex-direction: column;
+}
+
+.closeButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.35);
+  cursor: pointer;
+  padding: 0;
+  z-index: 1;
+  transition: color 0.12s ease;
+
+  &:hover {
+    color: rgba(255, 255, 255, 0.85);
+  }
+
+  svg {
+    width: 13px;
+    height: 13px;
+  }
+}
+
+.content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 16px;
+
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.15) transparent;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 2px;
+  }
+}
+
+// antd ColorPicker renders its panel in document.body at z-index ~1050.
+// Our popup is z-index 9999, so the panel ends up behind it — override globally.
+:global(.ant-color-picker-panel),
+:global(.ant-popover.ant-color-picker) {
+  z-index: 100000 !important;
+}
+
+// Adapt WidgetSettings (designed for ~680px) to fit the 420px popup.
+// All rules are scoped so they only affect popup content.
+.popupInner {
+  // ── Header ───────────────────────────────────────────────────
+  :global([class*='header']) {
+    margin-bottom: 14px !important;
+  }
+
+  :global([class*='moduleLabel']) {
+    font-size: 8px !important;
+    margin-bottom: 4px !important;
+  }
+
+  :global([class*='title']) {
+    font-size: 16px !important;
+  }
+
+  // ── Cards ─────────────────────────────────────────────────────
+  :global(
+    [class*='card']:not([class*='cardContent']):not([class*='cardTitle'])
+  ) {
+    margin-bottom: 12px !important;
+  }
+
+  :global([class*='cardTitle']) {
+    font-size: 9px !important;
+    margin-bottom: 8px !important;
+  }
+
+  :global([class*='cardContent']) {
+    padding: 12px !important;
+    overflow: hidden; // clip negative-margin bleed from antd Row
+  }
+
+  // ── antd 2-col grid → 1-col ───────────────────────────────────
+  :global(.ant-row) {
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    row-gap: 8px;
+  }
+
+  :global(.ant-col) {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    flex: 0 0 100% !important;
+    max-width: 100% !important;
+  }
+
+  // Full-width antd controls
+  :global(.ant-input-number),
+  :global(.ant-slider),
+  :global(.ant-segmented) {
+    width: 100% !important;
+  }
+
+  // ── Field labels ──────────────────────────────────────────────
+  :global([class*='fieldLabel']) {
+    font-size: 9px !important;
+    margin-bottom: 6px !important;
+  }
+
+  :global([class*='fieldGroup']) {
+    padding-bottom: 12px !important;
+    margin-bottom: 12px !important;
+  }
+
+  // ── SettingRow ────────────────────────────────────────────────
+  :global([class*='fieldRow']) {
+    gap: 10px;
+    align-items: center;
+  }
+
+  :global([class*='fieldTexts']) {
+    padding-right: 0 !important;
+    min-width: 0;
+    flex: 1;
+  }
+
+  :global([class*='fieldTitle']) {
+    font-size: 12px !important;
+    margin-bottom: 2px;
+  }
+
+  :global([class*='fieldDesc']) {
+    font-size: 10px !important;
+    white-space: normal;
+    word-break: break-word;
+    line-height: 1.35;
+  }
+
+  // ── Color picker row ──────────────────────────────────────────
+  :global([class*='colorPickerContainer']) {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}

--- a/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.tsx
+++ b/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { observer } from 'mobx-react-lite';
+import { useClickOutside } from '@hooks/common/useClickOutside';
 import { ConfigProvider, theme } from 'antd';
 import { X } from 'lucide-react';
 import { WidgetSettings } from '@app/main/components/WidgetSettings/WidgetSettings';
@@ -19,7 +19,7 @@ interface WidgetSettingsPopupProps {
 export const WidgetSettingsPopup = observer(
   ({ widgetId, onClose }: WidgetSettingsPopupProps) => {
     const widgetSettings = useWidgetSettingsStore();
-    const popupRef = useRef<HTMLDialogElement>(null);
+    const popupRef = useClickOutside<HTMLDialogElement>(onClose);
 
     const widget = widgetSettings.getWidget(widgetId);
     const widgetX = widget?.userSettings.x ?? 0;
@@ -38,18 +38,6 @@ export const WidgetSettingsPopup = observer(
       MARGIN,
       Math.min(widgetY, screenH - POPUP_MAX_HEIGHT - MARGIN)
     );
-
-    useEffect(() => {
-      const onMouseDown = (e: MouseEvent) => {
-        if (popupRef.current && !popupRef.current.contains(e.target as Node)) {
-          onClose();
-        }
-      };
-
-      document.addEventListener('mousedown', onMouseDown);
-
-      return () => document.removeEventListener('mousedown', onMouseDown);
-    }, [onClose]);
 
     return ReactDOM.createPortal(
       <ConfigProvider

--- a/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.tsx
+++ b/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.tsx
@@ -22,9 +22,14 @@ export const WidgetSettingsPopup = observer(
     const popupRef = useClickOutside<HTMLDialogElement>(onClose);
 
     const widget = widgetSettings.getWidget(widgetId);
-    const widgetX = widget?.userSettings.x ?? 0;
-    const widgetY = widget?.userSettings.y ?? 0;
-    const widgetW = widget?.userSettings.currentWidth ?? 200;
+
+    if (!widget) {
+      return null;
+    }
+
+    const widgetX = widget.userSettings.x;
+    const widgetY = widget.userSettings.y;
+    const widgetW = widget.userSettings.currentWidth;
 
     const screenH = window.innerHeight;
 

--- a/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.tsx
+++ b/src/app/overlay/components/WidgetDragToolbar/WidgetSettingsPopup/WidgetSettingsPopup.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { observer } from 'mobx-react-lite';
+import { ConfigProvider, theme } from 'antd';
+import { X } from 'lucide-react';
+import { WidgetSettings } from '@app/main/components/WidgetSettings/WidgetSettings';
+import { useWidgetSettingsStore } from '@store/root-store-context';
+import styles from './WidgetSettingsPopup.module.scss';
+
+const POPUP_WIDTH = 420;
+const POPUP_MAX_HEIGHT = 560;
+const MARGIN = 8;
+
+interface WidgetSettingsPopupProps {
+  widgetId: string;
+  onClose: () => void;
+}
+
+export const WidgetSettingsPopup = observer(
+  ({ widgetId, onClose }: WidgetSettingsPopupProps) => {
+    const widgetSettings = useWidgetSettingsStore();
+    const popupRef = useRef<HTMLDialogElement>(null);
+
+    const widget = widgetSettings.getWidget(widgetId);
+    const widgetX = widget?.userSettings.x ?? 0;
+    const widgetY = widget?.userSettings.y ?? 0;
+    const widgetW = widget?.userSettings.currentWidth ?? 200;
+
+    const screenH = window.innerHeight;
+
+    const spaceLeft = widgetX - MARGIN;
+    const popupX =
+      spaceLeft >= POPUP_WIDTH
+        ? widgetX - POPUP_WIDTH - MARGIN
+        : widgetX + widgetW + MARGIN;
+
+    const popupY = Math.max(
+      MARGIN,
+      Math.min(widgetY, screenH - POPUP_MAX_HEIGHT - MARGIN)
+    );
+
+    useEffect(() => {
+      const onMouseDown = (e: MouseEvent) => {
+        if (popupRef.current && !popupRef.current.contains(e.target as Node)) {
+          onClose();
+        }
+      };
+
+      document.addEventListener('mousedown', onMouseDown);
+
+      return () => document.removeEventListener('mousedown', onMouseDown);
+    }, [onClose]);
+
+    return ReactDOM.createPortal(
+      <ConfigProvider
+        theme={{
+          algorithm: theme.darkAlgorithm,
+          token: {
+            colorBgBase: '#0d0e12',
+            colorBgContainer: '#15161a',
+            colorBgElevated: '#1d1f25',
+            colorPrimary: '#e0e0e0',
+            zIndexPopupBase: 100000,
+          },
+        }}
+      >
+        <dialog
+          ref={popupRef}
+          className={styles.popup}
+          style={{ left: popupX, top: popupY, width: POPUP_WIDTH }}
+          open
+        >
+          <button
+            type="button"
+            className={styles.closeButton}
+            title="Close"
+            onClick={(e) => {
+              e.stopPropagation();
+              onClose();
+            }}
+          >
+            <X />
+          </button>
+
+          <div className={styles.content}>
+            <div className={styles.popupInner}>
+              <WidgetSettings widgetId={widgetId} />
+            </div>
+          </div>
+        </dialog>
+      </ConfigProvider>,
+      document.body
+    );
+  }
+);

--- a/src/hooks/common/useClickOutside.ts
+++ b/src/hooks/common/useClickOutside.ts
@@ -1,0 +1,19 @@
+import { useEffect, useRef } from 'react';
+
+export const useClickOutside = <T extends HTMLElement>(onClose: () => void) => {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const onMouseDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', onMouseDown);
+
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [onClose]);
+
+  return ref;
+};

--- a/src/store/sync/events.ts
+++ b/src/store/sync/events.ts
@@ -81,7 +81,7 @@ export const emitStandingsClassIndex = (index: number) =>
   emitTo(OVERLAY, 'standings-class-index-changed', index);
 export const emitWidgetSettingsUpdated = (widgets: WidgetDefaultConfig[]) =>
   emitTo(OVERLAY, 'widget-settings-updated', widgets);
+export const emitWidgetSettingsToMain = (widgets: WidgetDefaultConfig[]) =>
+  emitTo(MAIN, 'widget-settings-updated', widgets);
 export const emitOverlayMonitorChanged = (index: number | null) =>
   emitTo(OVERLAY, 'overlay-monitor-changed', index);
-export const emitWidgetLayoutChanged = (widgets: WidgetDefaultConfig[]) =>
-  emitTo(MAIN, 'widget-layout-changed', widgets);

--- a/src/store/sync/sync-init.ts
+++ b/src/store/sync/sync-init.ts
@@ -52,7 +52,7 @@ export const initMainSync = async (root: RootStore) => {
 
       const [overlayLayoutUnlisten, mainUnlistens] = await Promise.all([
         listen<WidgetDefaultConfig[]>('widget-layout-changed', (e) => {
-          root.widgetSettings.applyLayoutSync(e.payload);
+          root.widgetSettings.applySettingsSync(e.payload);
           void onSave();
         }),
         setupMainListeners(root),
@@ -204,7 +204,7 @@ export const initOverlaySync = async (root: RootStore) => {
       () => {
         void emitWidgetLayoutChanged(root.widgetSettings.allWidgets);
       },
-      { delay: 500 }
+      { delay: 100 }
     ),
   ];
 

--- a/src/store/sync/sync-init.ts
+++ b/src/store/sync/sync-init.ts
@@ -17,8 +17,8 @@ import {
   emitUnitsChanged,
   emitStandingsClassIndex,
   emitWidgetSettingsUpdated,
+  emitWidgetSettingsToMain,
   emitOverlayMonitorChanged,
-  emitWidgetLayoutChanged,
 } from './events';
 import type {
   WidgetDefaultConfig,
@@ -50,8 +50,8 @@ export const initMainSync = async (root: RootStore) => {
 
       const onSave = () => saveSettings(store, root);
 
-      const [overlayLayoutUnlisten, mainUnlistens] = await Promise.all([
-        listen<WidgetDefaultConfig[]>('widget-layout-changed', (e) => {
+      const [overlaySettingsUnlisten, mainUnlistens] = await Promise.all([
+        listen<WidgetDefaultConfig[]>('widget-settings-updated', (e) => {
           root.widgetSettings.applySettingsSync(e.payload);
           void onSave();
         }),
@@ -159,7 +159,7 @@ export const initMainSync = async (root: RootStore) => {
       ];
 
       return () => {
-        overlayLayoutUnlisten();
+        overlaySettingsUnlisten();
 
         mainUnlistens.forEach((u) => u());
         disposers.forEach((d) => d());
@@ -202,7 +202,7 @@ export const initOverlaySync = async (root: RootStore) => {
     reaction(
       () => root.widgetSettings.changeToken,
       () => {
-        void emitWidgetLayoutChanged(root.widgetSettings.allWidgets);
+        void emitWidgetSettingsToMain(root.widgetSettings.allWidgets);
       },
       { delay: 100 }
     ),


### PR DESCRIPTION
- Added `WidgetDragToolbar` — a toolbar on top of each widget in drag mode with two buttons: quick positioning (snap) and widget settings.
- `SnapPanel` — a 3x3 grid of buttons for instantly aligning the widget to the edges/center of the screen, taking into account margins.
- `WidgetSettingsPopup` — a pop-up widget settings panel directly in the overlay (without switching to the main window), positioned relative to the widget, taking into account the screen edges.
- Extracted the `useClickOutside` hook — used in both popups instead of duplicated `useEffect` + `useRef`.
- Simplified settings synchronization: two events (`widget-settings-updated` and `widget-layout-changed`) have been combined into one. `widget-settings-updated`