### PR TITLE
feat(timer): color-coded session header, fix END on checkered, normal…

### DIFF
--- a/src-tauri/src/model/session.rs
+++ b/src-tauri/src/model/session.rs
@@ -88,11 +88,22 @@ pub struct SessionSnapshot {
 }
 
 #[cfg_attr(feature = "dev", derive(specta::Type))]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq)]
+pub enum SessionType {
+    Practice,
+    Qualify,
+    Race,
+    #[default]
+    Unknown,
+}
+
+#[cfg_attr(feature = "dev", derive(specta::Type))]
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionEntry {
-    /// "Practice" | "Lone Qualify" | "Race" | ...
-    pub session_type: String,
+    pub session_type: SessionType,
+    /// Original label from the sim ("Lone Qualify", "Race", etc.) — use for display.
+    pub session_type_label: String,
     /// "unlimited" or a lap count as string (iRacing emits both forms).
     pub session_laps: String,
     pub results_positions: Vec<ResultPosition>,

--- a/src-tauri/src/sources/iracing/session_parse.rs
+++ b/src-tauri/src/sources/iracing/session_parse.rs
@@ -12,9 +12,48 @@ use super::weather::parse_weather_forecast;
 use crate::computations::proximity::parse_track_length;
 use crate::model::session::{
     CarEntry, QualifyResultEntry, ResultPosition, SectorEntry, SessionEntry, SessionSnapshot,
-    TireCompoundEntry,
+    SessionType, TireCompoundEntry,
 };
 use crate::sources::source::ParsedSession;
+
+#[derive(Deserialize, Default)]
+enum IracingSessionType {
+    Practice,
+    #[serde(rename = "Lone Qualify")]
+    LoneQualify,
+    #[serde(rename = "Open Qualify")]
+    OpenQualify,
+    Race,
+    #[serde(rename = "Offline Testing")]
+    OfflineTesting,
+    Warmup,
+    #[serde(other)]
+    #[default]
+    Unknown,
+}
+
+impl IracingSessionType {
+    fn to_session_type(&self) -> SessionType {
+        match self {
+            Self::Practice | Self::OfflineTesting | Self::Warmup => SessionType::Practice,
+            Self::LoneQualify | Self::OpenQualify => SessionType::Qualify,
+            Self::Race => SessionType::Race,
+            Self::Unknown => SessionType::Unknown,
+        }
+    }
+
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Practice => "Practice",
+            Self::LoneQualify => "Lone Qualify",
+            Self::OpenQualify => "Open Qualify",
+            Self::Race => "Race",
+            Self::OfflineTesting => "Offline Testing",
+            Self::Warmup => "Warmup",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
 
 /// iRacing emits these user-controlled text fields unquoted, so names like
 /// `? ?` or values containing `: ` break YAML parsing. Only these keys are
@@ -128,23 +167,27 @@ pub fn parse_session(yaml: &str) -> Option<ParsedSession> {
         .sessions
         .unwrap_or_default()
         .into_iter()
-        .map(|raw_session| SessionEntry {
-            session_type: raw_session.session_type.unwrap_or_default(),
-            session_laps: raw_session.session_laps.unwrap_or_default(),
-            results_positions: raw_session
-                .results_positions
-                .unwrap_or_default()
-                .into_iter()
-                .filter_map(|raw_pos| {
-                    Some(ResultPosition {
-                        car_idx: raw_pos.car_idx?,
-                        position: raw_pos.position?,
-                        class_position: raw_pos.class_position,
-                        lap: raw_pos.lap,
-                        time: raw_pos.time.filter(|t| t.is_finite()),
+        .map(|raw_session| {
+            let iracing_type = raw_session.session_type.unwrap_or_default();
+            SessionEntry {
+                session_type: iracing_type.to_session_type(),
+                session_type_label: iracing_type.label().to_string(),
+                session_laps: raw_session.session_laps.unwrap_or_default(),
+                results_positions: raw_session
+                    .results_positions
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|raw_pos| {
+                        Some(ResultPosition {
+                            car_idx: raw_pos.car_idx?,
+                            position: raw_pos.position?,
+                            class_position: raw_pos.class_position,
+                            lap: raw_pos.lap,
+                            time: raw_pos.time.filter(|t| t.is_finite()),
+                        })
                     })
-                })
-                .collect(),
+                    .collect(),
+            }
         })
         .collect();
 
@@ -314,7 +357,7 @@ struct RawSessionInfo {
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
 struct RawSessionEntry {
-    session_type: Option<String>,
+    session_type: Option<IracingSessionType>,
     session_laps: Option<String>,
     results_positions: Option<Vec<RawResultPosition>>,
 }
@@ -487,7 +530,8 @@ QualifyResultsInfo:
         assert_eq!(snapshot.current_session_num, 1);
         assert_eq!(snapshot.sessions.len(), 2);
         assert_eq!(snapshot.sessions[0].session_laps, "unlimited");
-        assert_eq!(snapshot.sessions[1].session_type, "Race");
+        assert_eq!(snapshot.sessions[1].session_type, SessionType::Race);
+        assert_eq!(snapshot.sessions[1].session_type_label, "Race");
         assert_eq!(snapshot.sessions[1].session_laps, "20");
         assert_eq!(snapshot.sessions[1].results_positions.len(), 2);
         assert_eq!(snapshot.sessions[1].results_positions[0].car_idx, 7);

--- a/src-tauri/src/sources/iracing/session_parse.rs
+++ b/src-tauri/src/sources/iracing/session_parse.rs
@@ -16,41 +16,35 @@ use crate::model::session::{
 };
 use crate::sources::source::ParsedSession;
 
-#[derive(Deserialize, Default)]
 enum IracingSessionType {
     Practice,
-    #[serde(rename = "Lone Qualify")]
     LoneQualify,
-    #[serde(rename = "Open Qualify")]
     OpenQualify,
     Race,
-    #[serde(rename = "Offline Testing")]
     OfflineTesting,
     Warmup,
-    #[serde(other)]
-    #[default]
     Unknown,
 }
 
 impl IracingSessionType {
+    fn from_str(s: &str) -> Self {
+        match s {
+            "Practice" => Self::Practice,
+            "Lone Qualify" => Self::LoneQualify,
+            "Open Qualify" => Self::OpenQualify,
+            "Race" => Self::Race,
+            "Offline Testing" => Self::OfflineTesting,
+            "Warmup" => Self::Warmup,
+            _ => Self::Unknown,
+        }
+    }
+
     fn to_session_type(&self) -> SessionType {
         match self {
             Self::Practice | Self::OfflineTesting | Self::Warmup => SessionType::Practice,
             Self::LoneQualify | Self::OpenQualify => SessionType::Qualify,
             Self::Race => SessionType::Race,
             Self::Unknown => SessionType::Unknown,
-        }
-    }
-
-    fn label(&self) -> &'static str {
-        match self {
-            Self::Practice => "Practice",
-            Self::LoneQualify => "Lone Qualify",
-            Self::OpenQualify => "Open Qualify",
-            Self::Race => "Race",
-            Self::OfflineTesting => "Offline Testing",
-            Self::Warmup => "Warmup",
-            Self::Unknown => "Unknown",
         }
     }
 }
@@ -168,10 +162,11 @@ pub fn parse_session(yaml: &str) -> Option<ParsedSession> {
         .unwrap_or_default()
         .into_iter()
         .map(|raw_session| {
-            let iracing_type = raw_session.session_type.unwrap_or_default();
+            let raw_label = raw_session.session_type.unwrap_or_default();
+            let iracing_type = IracingSessionType::from_str(&raw_label);
             SessionEntry {
                 session_type: iracing_type.to_session_type(),
-                session_type_label: iracing_type.label().to_string(),
+                session_type_label: raw_label,
                 session_laps: raw_session.session_laps.unwrap_or_default(),
                 results_positions: raw_session
                     .results_positions
@@ -357,7 +352,7 @@ struct RawSessionInfo {
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
 struct RawSessionEntry {
-    session_type: Option<IracingSessionType>,
+    session_type: Option<String>,
     session_laps: Option<String>,
     results_positions: Option<Vec<RawResultPosition>>,
 }

--- a/src/types/bindings.ts
+++ b/src/types/bindings.ts
@@ -709,10 +709,11 @@ export type ResultPosition = {
 export type SectorEntry = { sectorNum: number; sectorStartPct: number };
 
 export type SessionEntry = {
+  sessionType: SessionType;
   /**
-   * "Practice" | "Lone Qualify" | "Race" | ...
+   * Original label from the sim ("Lone Qualify", "Race", etc.) — use for display.
    */
-  sessionType: string;
+  sessionTypeLabel: string;
   /**
    * "unlimited" or a lap count as string (iRacing emits both forms).
    */
@@ -819,6 +820,8 @@ export type SessionState =
   | 'Racing'
   | 'Checkered'
   | 'CoolDown';
+
+export type SessionType = 'Practice' | 'Qualify' | 'Race' | 'Unknown';
 
 /**
  * Status payload emitted as `sim://status`.

--- a/src/utils/widget/timer-utils.ts
+++ b/src/utils/widget/timer-utils.ts
@@ -1,4 +1,4 @@
-import type { SessionState } from '@/types/bindings';
+import type { SessionState, SessionType } from '@/types/bindings';
 
 export type FlagState = 'green' | 'final' | 'checkered';
 
@@ -117,7 +117,27 @@ export const isSessionEnded = (sessionState: SessionState | null): boolean => {
     return false;
   }
 
-  return sessionState === 'Checkered' || sessionState === 'CoolDown';
+  return sessionState === 'CoolDown';
+};
+
+export type SessionColorKey = 'practice' | 'qualify' | 'race' | 'other';
+
+export const resolveSessionColorKey = (
+  sessionType: SessionType
+): SessionColorKey => {
+  if (sessionType === 'Practice') {
+    return 'practice';
+  }
+
+  if (sessionType === 'Qualify') {
+    return 'qualify';
+  }
+
+  if (sessionType === 'Race') {
+    return 'race';
+  }
+
+  return 'other';
 };
 
 export const splitTime = (seconds: number): { main: string; secs: string } => {

--- a/src/widgets/TimerWidget/TimerHeader/TimerHeader.module.scss
+++ b/src/widgets/TimerWidget/TimerHeader/TimerHeader.module.scss
@@ -1,13 +1,46 @@
 .header {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
-  padding: sp(sm) sp(sm) sp(xxxs);
+  padding: sp(xs) sp(sm);
+  border-radius: radius(md) radius(md) 0 0;
 }
 
 .sessionLabel {
   font-family: $font-mono;
   font-size: fs(xxxs);
-  color: $widget-text-secondary;
-  letter-spacing: 1px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+}
+
+.sessionPractice {
+  background-color: rgba($race-blue, 0.15);
+
+  .sessionLabel {
+    color: $race-blue;
+  }
+}
+
+.sessionQualify {
+  background-color: rgba($race-purple, 0.15);
+
+  .sessionLabel {
+    color: $race-purple;
+  }
+}
+
+.sessionRace {
+  background-color: rgba($race-green, 0.15);
+
+  .sessionLabel {
+    color: $race-green;
+  }
+}
+
+.sessionOther {
+  background-color: rgba(#ffffff, 0.06);
+
+  .sessionLabel {
+    color: $widget-text-secondary;
+  }
 }

--- a/src/widgets/TimerWidget/TimerHeader/TimerHeader.tsx
+++ b/src/widgets/TimerWidget/TimerHeader/TimerHeader.tsx
@@ -1,10 +1,13 @@
 import { observer } from 'mobx-react-lite';
 
-import { resolveSessionColorKey } from '@utils/widget/timer-utils';
+import {
+  resolveSessionColorKey,
+  type SessionColorKey,
+} from '@utils/widget/timer-utils';
 import { useSessionStore } from '@store/root-store-context';
 import styles from './TimerHeader.module.scss';
 
-const SESSION_LABEL_CLASS: Record<string, string> = {
+const SESSION_LABEL_CLASS: Record<SessionColorKey, string> = {
   practice: styles.sessionPractice,
   qualify: styles.sessionQualify,
   race: styles.sessionRace,

--- a/src/widgets/TimerWidget/TimerHeader/TimerHeader.tsx
+++ b/src/widgets/TimerWidget/TimerHeader/TimerHeader.tsx
@@ -1,30 +1,31 @@
-﻿import { observer } from 'mobx-react-lite';
+import { observer } from 'mobx-react-lite';
 
-import { TimerFlagBadge } from './TimerFlagBadge/TimerFlagBadge';
+import { resolveSessionColorKey } from '@utils/widget/timer-utils';
 import { useSessionStore } from '@store/root-store-context';
 import styles from './TimerHeader.module.scss';
-import { WidgetLabel } from '@/components/shared/WidgetLabel/WidgetLabel';
+
+const SESSION_LABEL_CLASS: Record<string, string> = {
+  practice: styles.sessionPractice,
+  qualify: styles.sessionQualify,
+  race: styles.sessionRace,
+  other: styles.sessionOther,
+};
 
 export const TimerHeader = observer(() => {
   const { session, sessionInfo } = useSessionStore();
 
   const sessions = sessionInfo?.sessions ?? [];
-
   const sessionNum = session?.session_num ?? null;
-
   const currentSession =
     sessionNum !== null ? (sessions[sessionNum] ?? null) : null;
-
+  const sessionType = currentSession?.sessionType ?? 'Unknown';
+  const colorKey = resolveSessionColorKey(sessionType);
   const sessionTypeLabel =
-    currentSession?.sessionType.toUpperCase() || 'NO SESSION';
+    currentSession?.sessionTypeLabel.toUpperCase() ?? 'NO SESSION';
 
   return (
-    <div className={styles.header}>
-      <WidgetLabel className={styles.sessionLabel}>
-        {sessionTypeLabel}
-      </WidgetLabel>
-
-      <TimerFlagBadge />
+    <div className={`${styles.header} ${SESSION_LABEL_CLASS[colorKey]}`}>
+      <span className={styles.sessionLabel}>{sessionTypeLabel}</span>
     </div>
   );
 });

--- a/src/widgets/TimerWidget/TimerWidget.stories.tsx
+++ b/src/widgets/TimerWidget/TimerWidget.stories.tsx
@@ -1,4 +1,4 @@
-﻿import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 
 import type {
   CarIdxFrame,
@@ -6,6 +6,7 @@ import type {
   SessionFrame,
   SessionSnapshot,
   SessionState as BindingSessionState,
+  SessionType,
 } from '@/types/bindings';
 import { TimerWidget } from './TimerWidget';
 import { defineWidgetStories } from '@/storybook/define-widget-stories';
@@ -20,7 +21,8 @@ const buildCarIdxLap = (lap: number): number[] => {
 };
 
 interface StoryArgs {
-  sessionType: string;
+  sessionType: SessionType;
+  sessionTypeLabel: string;
   sessionLaps: string;
   remainSec: number | null;
   elapsedSec: number;
@@ -30,7 +32,6 @@ interface StoryArgs {
   currentLap: number;
   position: number;
   totalDrivers: number;
-  showFlag: boolean;
   showLaps: boolean;
   showPosition: boolean;
   showWallClock: boolean;
@@ -54,6 +55,7 @@ const meta: Meta<StoryArgs> = {
         sessions: [
           {
             sessionType: args.sessionType,
+            sessionTypeLabel: args.sessionTypeLabel,
             sessionLaps: String(args.sessionLaps),
             resultsPositions: [],
           },
@@ -79,7 +81,6 @@ const meta: Meta<StoryArgs> = {
       } as LapTimingFrame);
 
       store.widgetSettings.updateUserSettings('timer', {
-        showFlag: args.showFlag,
         showLaps: args.showLaps,
         showPosition: args.showPosition,
         showWallClock: args.showWallClock,
@@ -89,7 +90,8 @@ const meta: Meta<StoryArgs> = {
       });
     },
     args: {
-      sessionType: 'RACE',
+      sessionType: 'Race',
+      sessionTypeLabel: 'Race',
       sessionLaps: '30',
       remainSec: 42 * 60 + 18,
       elapsedSec: 0,
@@ -99,7 +101,6 @@ const meta: Meta<StoryArgs> = {
       currentLap: 12,
       position: 5,
       totalDrivers: 24,
-      showFlag: true,
       showLaps: true,
       showPosition: true,
       showWallClock: false,
@@ -117,11 +118,36 @@ export const RaceGreen: Story = {};
 
 export const Practice: Story = {
   args: {
-    sessionType: 'PRACTICE',
+    sessionType: 'Practice',
+    sessionTypeLabel: 'Practice',
     sessionLaps: 'unlimited',
     remainSec: 18 * 60 + 42,
     showLaps: false,
     showPosition: false,
+  },
+};
+
+export const LoneQualify: Story = {
+  args: {
+    sessionType: 'Qualify',
+    sessionTypeLabel: 'Lone Qualify',
+    sessionLaps: 'unlimited',
+    remainSec: 12 * 60,
+    showLaps: false,
+    showPosition: true,
+    position: 3,
+  },
+};
+
+export const OpenQualify: Story = {
+  args: {
+    sessionType: 'Qualify',
+    sessionTypeLabel: 'Open Qualify',
+    sessionLaps: 'unlimited',
+    remainSec: 12 * 60,
+    showLaps: false,
+    showPosition: true,
+    position: 3,
   },
 };
 
@@ -134,7 +160,7 @@ export const Checkered: Story = {
 };
 
 export const SessionEnded: Story = {
-  args: { sessionState: 'Checkered' },
+  args: { sessionState: 'CoolDown' },
 };
 
 export const WithClocks: Story = {
@@ -142,18 +168,11 @@ export const WithClocks: Story = {
 };
 
 export const MinimalView: Story = {
-  args: { showFlag: false, showLaps: false, showPosition: false },
+  args: { showLaps: false, showPosition: false },
 };
 
-export const Qualifying: Story = {
-  args: {
-    sessionType: 'QUALIFY',
-    sessionLaps: 'unlimited',
-    remainSec: 12 * 60,
-    showLaps: false,
-    showPosition: true,
-    position: 3,
-  },
+export const TimedRace: Story = {
+  args: { sessionLaps: 'unlimited', remainSec: 30 * 60, currentLap: 8 },
 };
 
 export const WithDates: Story = {
@@ -164,8 +183,4 @@ export const WithDates: Story = {
     showSimDate: true,
     simTimeOfDay: 14 * 3600 + 23 * 60,
   },
-};
-
-export const TimedRace: Story = {
-  args: { sessionLaps: 'unlimited', remainSec: 30 * 60, currentLap: 8 },
 };


### PR DESCRIPTION
…ize SessionType

  - TimerHeader: replace flag badge with session type label colored by category (Practice → blue, Qualify → purple, Race → green, header bg is muted tint)
  - TimerDisplay: show END only on CoolDown state, not Checkered — timer keeps running after the checkered flag until the session actually ends
  - model/session.rs: add sim-agnostic SessionType enum (Practice | Qualify | Race | Unknown) and session_type_label: String for original sim display string
  - sources/iracing: IracingSessionType stays local, maps to SessionType on parse; Offline Testing and Warmup normalize to Practice, Lone/Open Qualify to Qualify
  - timer-utils.ts: resolveSessionColorKey takes SessionType from bindings — no casts, no string matching
  - bindings.ts: regenerated with SessionType union and updated SessionEntry