### PR TITLE
feat(standings,relative): layout polish — class color on pos, column reorder, player row gradient

### DIFF
--- a/src/styles/_widget-tokens.scss
+++ b/src/styles/_widget-tokens.scss
@@ -52,6 +52,13 @@ $widget-row-border: rgba(39, 39, 42, 0.5);
 $widget-row-hover: rgba(39, 39, 42, 0.3);
 $widget-row-bg-subtle: rgba(24, 24, 27, 0.2);
 $widget-row-player-bg: rgba($race-yellow, 0.1);
+$widget-row-player-gradient: linear-gradient(
+  to right,
+  transparent,
+  rgba($race-yellow, 0.13) 40%,
+  rgba($race-yellow, 0.13) 60%,
+  transparent
+);
 
 // Tints — translucent fills derived from palette (row highlights, sector cells)
 $widget-tint-positive: rgba($race-green, 0.12);

--- a/src/utils/widget/relative-utils.ts
+++ b/src/utils/widget/relative-utils.ts
@@ -18,8 +18,8 @@ interface ColSpec {
 // Single source of truth for column order + widths (px at scale 1). Order MUST
 // match the render order in DriverRow.tsx.
 const colSpecs = (settings: RelativeWidgetSettings): ColSpec[] => [
-  { px: 20, show: true }, // pos
-  { px: 40, show: true }, // carNum
+  { px: 28, show: true }, // pos — wider for # prefix + class color padding
+  { px: 36, show: true }, // carNum
   { px: NAME_NATURAL_PX, show: true, flex: true }, // name
   { px: 48, show: settings.showLicBadge }, // lic badge
   { px: 36, show: settings.showIRating }, // iRating

--- a/src/utils/widget/relative-utils.ts
+++ b/src/utils/widget/relative-utils.ts
@@ -18,8 +18,8 @@ interface ColSpec {
 // Single source of truth for column order + widths (px at scale 1). Order MUST
 // match the render order in DriverRow.tsx.
 const colSpecs = (settings: RelativeWidgetSettings): ColSpec[] => [
-  { px: 28, show: true }, // pos — wider for # prefix + class color padding
-  { px: 36, show: true }, // carNum
+  { px: 28, show: true }, // pos — wider for class color padding
+  { px: 36, show: true }, // carNum — with # prefix
   { px: NAME_NATURAL_PX, show: true, flex: true }, // name
   { px: 48, show: settings.showLicBadge }, // lic badge
   { px: 36, show: settings.showIRating }, // iRating

--- a/src/utils/widget/standings-utils.ts
+++ b/src/utils/widget/standings-utils.ts
@@ -60,9 +60,9 @@ interface ColSpec {
 }
 
 const colSpecs = (settings: StandingsWidgetSettings): ColSpec[] => [
-  { px: 28, show: true }, // pos      "#00" (fs lg, bold) — wider for # prefix + class color
+  { px: 28, show: true }, // pos      "00" (fs lg, bold) — wider for class color
   { px: 38, show: settings.showPosChange }, // +/- pos  "▲12" — between pos and carNum
-  { px: 40, show: true }, // carNum   "000" + cell padding
+  { px: 40, show: true }, // carNum   "#000" + cell padding
   { px: NAME_NATURAL_PX, show: true, flex: true }, // name — flexes, never collapses
   { px: 54, show: settings.showLicBadge }, // lic badge "A 4.99"
   { px: 42, show: settings.showIRating }, // iRating  "9.9k"

--- a/src/utils/widget/standings-utils.ts
+++ b/src/utils/widget/standings-utils.ts
@@ -60,14 +60,14 @@ interface ColSpec {
 }
 
 const colSpecs = (settings: StandingsWidgetSettings): ColSpec[] => [
-  { px: 22, show: true }, // pos      "00" (fs lg, bold)
-  { px: 46, show: true }, // carNum   "#000" + cell padding
+  { px: 28, show: true }, // pos      "#00" (fs lg, bold) — wider for # prefix + class color
+  { px: 38, show: settings.showPosChange }, // +/- pos  "▲12" — between pos and carNum
+  { px: 40, show: true }, // carNum   "000" + cell padding
   { px: NAME_NATURAL_PX, show: true, flex: true }, // name — flexes, never collapses
   { px: 54, show: settings.showLicBadge }, // lic badge "A 4.99"
   { px: 42, show: settings.showIRating }, // iRating  "9.9k"
   { px: 42, show: settings.showIrChange }, // ΔiR     "+123"
   { px: 28, show: settings.showLapsCompleted }, // laps "00"
-  { px: 38, show: settings.showPosChange }, // +/- pos  "▲12"
   { px: 50, show: true }, // gap      "+123.4" / "12 L"
   { px: 82, show: true }, // last     "--:--.---" (9 chars mono)
   { px: 82, show: true }, // best     "--:--.---" (9 chars mono)

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
@@ -4,12 +4,11 @@
   display: grid;
   align-items: center;
   column-gap: sp(xxxs);
-  padding: sp(xxs) sp(sm);
+  padding: sp(xs) sp(md);
   position: relative;
   border-bottom: 1px solid $widget-row-border;
-  background: $widget-row-bg-subtle;
   line-height: 1.15;
-  font-size: fs(sm);
+  font-size: fs(md);
 }
 
 .rowOdd {
@@ -18,11 +17,7 @@
 
 .driverRowPlayer {
   z-index: 10;
-  background: linear-gradient(
-    to right,
-    transparent ws(68),
-    rgba($race-yellow, 0.11) ws(110)
-  );
+  background-color: $widget-row-player-bg;
 }
 
 .driverRowPit {
@@ -35,9 +30,9 @@
   display: flex;
   align-items: center;
   align-self: stretch;
-  margin-top: calc(-1 * sp(xxs));
-  margin-bottom: calc(-1 * sp(xxs));
-  padding: sp(xxs) sp(xxs);
+  margin-top: calc(-1 * sp(xs));
+  margin-bottom: calc(-1 * sp(xs));
+  padding: sp(xs) sp(xs);
 }
 
 // Position — primary emphasis
@@ -49,7 +44,7 @@
 }
 
 .driverPositionPlayer {
-  color: $widget-status-caution;
+  color: $widget-text-primary;
 }
 
 // Car number cell
@@ -87,7 +82,7 @@
 }
 
 .driverNamePlayer {
-  color: $widget-status-caution;
+  color: $widget-text-primary;
 }
 
 .driverNameLappedBehind {

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
@@ -25,14 +25,15 @@
   filter: grayscale(100%);
 }
 
-// Position block — stretches full row height for class color border + gradient
+// Position block — stretches to row edges for class color border + gradient
 .posBlock {
   display: flex;
   align-items: center;
   align-self: stretch;
   margin-top: calc(-1 * sp(xs));
   margin-bottom: calc(-1 * sp(xs));
-  padding: sp(xs) sp(xs);
+  margin-left: calc(-1 * sp(md));
+  padding: sp(xs) sp(xs) sp(xs) sp(md);
 }
 
 // Position — primary emphasis

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
@@ -17,8 +17,17 @@
 }
 
 .driverRowPlayer {
-  background-color: $widget-row-player-bg;
+  background-color: transparent;
   z-index: 10;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    left: calc(ws(20) + sp(xxxs));
+    background: rgba($race-yellow, 0.07);
+    pointer-events: none;
+  }
 }
 
 .driverRowPit {
@@ -26,10 +35,14 @@
   filter: grayscale(100%);
 }
 
-// Position block
+// Position block — stretches full row height for class color border + gradient
 .posBlock {
   display: flex;
-  align-items: baseline;
+  align-items: center;
+  align-self: stretch;
+  margin-top: calc(-1 * sp(xxs));
+  margin-bottom: calc(-1 * sp(xxs));
+  padding: sp(xxs) sp(xxs);
 }
 
 // Position — primary emphasis
@@ -44,25 +57,18 @@
   color: $widget-status-caution;
 }
 
-// Car number cell — second grid column after pos
-// Negative margins compensate for row padding so border+gradient reach full row height
+// Car number cell
 .carNumberCell {
-  align-self: stretch;
-  margin-top: calc(-1 * sp(xxs));
-  margin-bottom: calc(-1 * sp(xxs));
   display: flex;
   align-items: center;
-  padding: sp(xxs) sp(xxs);
+  padding: 0 sp(xxs);
 }
 
+// Car number — muted, class identity comes from pos column color
 .driverCarNumber {
   font-size: fs(xs);
   font-family: $font-mono;
-  color: $widget-text-primary;
-}
-
-.driverCarNumberPlayer {
-  color: $widget-status-position-gain;
+  color: $widget-text-muted;
 }
 
 // Info block — name only, fills 1fr grid column

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
@@ -17,7 +17,15 @@
 
 .driverRowPlayer {
   z-index: 10;
-  background-color: $widget-row-player-bg;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    left: var(--hl-left, 0);
+    background-color: $widget-row-player-bg;
+    pointer-events: none;
+  }
 }
 
 .driverRowPit {

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
@@ -17,15 +17,7 @@
 
 .driverRowPlayer {
   z-index: 10;
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    left: var(--hl-left, 0);
-    background-color: $widget-row-player-bg;
-    pointer-events: none;
-  }
+  background: $widget-row-player-gradient;
 }
 
 .driverRowPit {

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.module.scss
@@ -17,17 +17,12 @@
 }
 
 .driverRowPlayer {
-  background-color: transparent;
   z-index: 10;
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    left: calc(ws(20) + sp(xxxs));
-    background: rgba($race-yellow, 0.07);
-    pointer-events: none;
-  }
+  background: linear-gradient(
+    to right,
+    transparent ws(68),
+    rgba($race-yellow, 0.11) ws(110)
+  );
 }
 
 .driverRowPit {

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   abbreviateName,
@@ -82,20 +81,10 @@ export const DriverRow = observer(({ driver, index }: DriverRowProps) => {
 
   const gridTemplate = buildRelativeGridTemplate(settings);
 
-  // pos(28) + gap(2) + carNum(36) + gap(2) + rowPadL(10)
-  const hlLeft = driver.isPlayer
-    ? `calc(14px + 64px * var(--wfs, 1))`
-    : undefined;
-
   return (
     <div
       className={rowClass}
-      style={
-        {
-          gridTemplateColumns: gridTemplate,
-          '--hl-left': hlLeft,
-        } as React.CSSProperties
-      }
+      style={{ gridTemplateColumns: gridTemplate }}
       data-relative-row
     >
       <div

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
@@ -101,7 +101,7 @@ export const DriverRow = observer(({ driver, index }: DriverRowProps) => {
       <div
         className={styles.posBlock}
         style={{
-          borderLeft: `4px solid ${driver.carClassColor}`,
+          borderLeft: `3px solid ${driver.carClassColor}`,
           background: `linear-gradient(to right, ${driver.carClassColor}33, transparent)`,
         }}
       >

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
@@ -91,7 +91,7 @@ export const DriverRow = observer(({ driver, index }: DriverRowProps) => {
         className={styles.posBlock}
         style={{
           borderLeft: `3px solid ${driver.carClassColor}`,
-          background: `linear-gradient(to right, ${driver.carClassColor}33, transparent)`,
+          background: `linear-gradient(to right, color-mix(in srgb, ${driver.carClassColor} 20%, transparent), transparent)`,
         }}
       >
         <span

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
@@ -87,7 +87,13 @@ export const DriverRow = observer(({ driver, index }: DriverRowProps) => {
       style={{ gridTemplateColumns: gridTemplate }}
       data-relative-row
     >
-      <div className={styles.posBlock}>
+      <div
+        className={styles.posBlock}
+        style={{
+          borderLeft: `4px solid ${driver.carClassColor}`,
+          background: `linear-gradient(to right, ${driver.carClassColor}33, transparent)`,
+        }}
+      >
         <span
           className={`${styles.driverPosition} ${driver.isPlayer ? styles.driverPositionPlayer : ''}`}
         >
@@ -95,18 +101,8 @@ export const DriverRow = observer(({ driver, index }: DriverRowProps) => {
         </span>
       </div>
 
-      <div
-        className={styles.carNumberCell}
-        style={{
-          borderLeft: `4px solid ${driver.carClassColor}`,
-          background: `linear-gradient(to right, ${driver.carClassColor}33, transparent)`,
-        }}
-      >
-        <span
-          className={`${styles.driverCarNumber} ${driver.isPlayer ? styles.driverCarNumberPlayer : ''}`}
-        >
-          #{formattedCarNumber}
-        </span>
+      <div className={styles.carNumberCell}>
+        <span className={styles.driverCarNumber}>#{formattedCarNumber}</span>
       </div>
 
       <div className={styles.infoBlock}>

--- a/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/RelativeWidget/DriverRow/DriverRow.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { observer } from 'mobx-react-lite';
 import {
   abbreviateName,
@@ -81,10 +82,20 @@ export const DriverRow = observer(({ driver, index }: DriverRowProps) => {
 
   const gridTemplate = buildRelativeGridTemplate(settings);
 
+  // pos(28) + gap(2) + carNum(36) + gap(2) + rowPadL(10)
+  const hlLeft = driver.isPlayer
+    ? `calc(14px + 64px * var(--wfs, 1))`
+    : undefined;
+
   return (
     <div
       className={rowClass}
-      style={{ gridTemplateColumns: gridTemplate }}
+      style={
+        {
+          gridTemplateColumns: gridTemplate,
+          '--hl-left': hlLeft,
+        } as React.CSSProperties
+      }
       data-relative-row
     >
       <div

--- a/src/widgets/RelativeWidget/RelativeWidget.stories.tsx
+++ b/src/widgets/RelativeWidget/RelativeWidget.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-import type { DriverEntriesFrame } from '@/types/bindings';
+import type { RelativeFrame } from '@/types/bindings';
 import type { RelativeWidgetSettings } from '@/types/widget-settings';
 import { driverEntries } from '@/storybook/test-data';
 import { RelativeWidget } from './RelativeWidget';
@@ -34,10 +34,10 @@ const meta: Meta<StoryArgs> = {
     widget: RelativeWidget,
     size: { width: 406, height: 400 },
     seed: (store, args) => {
-      store.backendComputed.updateStandings({
+      store.backendComputed.updateRelative({
         entries: DRIVER_ENTRIES,
         playerCarIdx: PLAYER_CAR_IDX,
-      } as DriverEntriesFrame);
+      } as RelativeFrame);
 
       store.widgetSettings.updateUserSettings('relative', args.settings);
     },

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
@@ -23,6 +23,7 @@
 
 .driverRowOffTrack {
   opacity: 0.5;
+  filter: grayscale(100%);
 }
 
 // Base cell

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
@@ -42,12 +42,13 @@
   justify-content: flex-end;
 }
 
-// Position cell — stretch full row height for class color border + gradient
+// Position cell — stretch to row edges for class color border + gradient
 .posCell {
   align-self: stretch;
   margin-top: calc(-1 * sp(xs));
   margin-bottom: calc(-1 * sp(xs));
-  padding: sp(xs) sp(xs);
+  margin-left: calc(-1 * sp(md));
+  padding: sp(xs) sp(xs) sp(xs) sp(md);
 }
 
 // Car number cell

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
@@ -18,7 +18,14 @@
 }
 
 .driverRowPlayer {
-  background-color: $widget-row-player-bg;
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    left: var(--hl-left, 0);
+    background-color: $widget-row-player-bg;
+    pointer-events: none;
+  }
 }
 
 .driverRowOffTrack {

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
@@ -18,16 +18,11 @@
 }
 
 .driverRowPlayer {
-  background-color: transparent;
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    left: calc(ws(28) + sp(xxxs));
-    background: rgba($race-yellow, 0.07);
-    pointer-events: none;
-  }
+  background: linear-gradient(
+    to right,
+    transparent ws(72),
+    rgba($race-yellow, 0.11) ws(120)
+  );
 }
 
 .driverRowOffTrack {

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
@@ -18,14 +18,7 @@
 }
 
 .driverRowPlayer {
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    left: var(--hl-left, 0);
-    background-color: $widget-row-player-bg;
-    pointer-events: none;
-  }
+  background: $widget-row-player-gradient;
 }
 
 .driverRowOffTrack {

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
@@ -18,11 +18,7 @@
 }
 
 .driverRowPlayer {
-  background: linear-gradient(
-    to right,
-    transparent ws(72),
-    rgba($race-yellow, 0.11) ws(120)
-  );
+  background-color: $widget-row-player-bg;
 }
 
 .driverRowOffTrack {
@@ -73,7 +69,7 @@
 }
 
 .posNumberPlayer {
-  color: $widget-status-caution;
+  color: $widget-text-primary;
 }
 
 // Position change
@@ -124,7 +120,7 @@
 }
 
 .driverNamePlayer {
-  color: $widget-status-caution;
+  color: $widget-text-primary;
 }
 
 // Class badge

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.module.scss
@@ -18,7 +18,16 @@
 }
 
 .driverRowPlayer {
-  background-color: $widget-row-player-bg;
+  background-color: transparent;
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    left: calc(ws(28) + sp(xxxs));
+    background: rgba($race-yellow, 0.07);
+    pointer-events: none;
+  }
 }
 
 .driverRowOffTrack {
@@ -42,12 +51,17 @@
   justify-content: flex-end;
 }
 
-// Car number cell — stretch full row height for border + gradient
-.carNumberCell {
+// Position cell — stretch full row height for class color border + gradient
+.posCell {
   align-self: stretch;
   margin-top: calc(-1 * sp(xs));
   margin-bottom: calc(-1 * sp(xs));
   padding: sp(xs) sp(xs);
+}
+
+// Car number cell
+.carNumberCell {
+  padding: 0 sp(xxs);
 }
 
 // Name cell — overflow truncation
@@ -56,13 +70,14 @@
   gap: sp(xs);
 }
 
-// Position
-.posCell {
+// Position number
+.posNumber {
   font-weight: 700;
   font-size: fs(md);
+  color: $widget-text-primary;
 }
 
-.posCellPlayer {
+.posNumberPlayer {
   color: $widget-status-caution;
 }
 
@@ -94,15 +109,11 @@
   justify-content: center;
 }
 
-// Car number
+// Car number — muted, class identity comes from pos column color
 .carNumber {
   font-family: $font-mono;
   font-size: fs(md);
-  color: $widget-text-primary;
-}
-
-.carNumberPlayer {
-  color: $widget-status-position-gain;
+  color: $widget-text-muted;
 }
 
 // Driver name

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
@@ -1,5 +1,4 @@
-﻿import React from 'react';
-import { observer } from 'mobx-react-lite';
+﻿import { observer } from 'mobx-react-lite';
 import { formatLapTime } from '@utils/formatters/telemetry-format';
 import {
   abbreviateName,
@@ -96,22 +95,10 @@ export const DriverRow = observer(({ carIdx, index }: DriverRowProps) => {
     <span className={styles.gapValue}>{gapInfo.value}</span>
   );
 
-  // pos(28) + gap(2) + [posChange(38) + gap(2)] + carNum(40) + gap(2) + rowPadL(10)
-  const hlSkipCols = settings.showPosChange ? 106 : 68;
-  const hlExtraPx = settings.showPosChange ? 16 : 14;
-  const hlLeft = driver.isPlayer
-    ? `calc(${hlExtraPx}px + ${hlSkipCols}px * var(--wfs, 1))`
-    : undefined;
-
   return (
     <div
       className={rowClass}
-      style={
-        {
-          gridTemplateColumns: gridTemplate,
-          '--hl-left': hlLeft,
-        } as React.CSSProperties
-      }
+      style={{ gridTemplateColumns: gridTemplate }}
       data-driver-row
     >
       <div

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
@@ -1,4 +1,5 @@
-﻿import { observer } from 'mobx-react-lite';
+﻿import React from 'react';
+import { observer } from 'mobx-react-lite';
 import { formatLapTime } from '@utils/formatters/telemetry-format';
 import {
   abbreviateName,
@@ -95,10 +96,22 @@ export const DriverRow = observer(({ carIdx, index }: DriverRowProps) => {
     <span className={styles.gapValue}>{gapInfo.value}</span>
   );
 
+  // pos(28) + gap(2) + [posChange(38) + gap(2)] + carNum(40) + gap(2) + rowPadL(10)
+  const hlSkipCols = settings.showPosChange ? 106 : 68;
+  const hlExtraPx = settings.showPosChange ? 16 : 14;
+  const hlLeft = driver.isPlayer
+    ? `calc(${hlExtraPx}px + ${hlSkipCols}px * var(--wfs, 1))`
+    : undefined;
+
   return (
     <div
       className={rowClass}
-      style={{ gridTemplateColumns: gridTemplate }}
+      style={
+        {
+          gridTemplateColumns: gridTemplate,
+          '--hl-left': hlLeft,
+        } as React.CSSProperties
+      }
       data-driver-row
     >
       <div

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
@@ -105,7 +105,7 @@ export const DriverRow = observer(({ carIdx, index }: DriverRowProps) => {
         className={`${styles.cell} ${styles.posCell}`}
         style={{
           borderLeft: `3px solid ${driver.carClassColor}`,
-          background: `linear-gradient(to right, ${driver.carClassColor}33, transparent)`,
+          background: `linear-gradient(to right, color-mix(in srgb, ${driver.carClassColor} 20%, transparent), transparent)`,
         }}
       >
         <span

--- a/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
+++ b/src/widgets/StandingsWidget/DriverRow/DriverRow.tsx
@@ -101,26 +101,28 @@ export const DriverRow = observer(({ carIdx, index }: DriverRowProps) => {
       style={{ gridTemplateColumns: gridTemplate }}
       data-driver-row
     >
-      <div className={styles.cell}>
-        <span
-          className={`${styles.posCell} ${driver.isPlayer ? styles.posCellPlayer : ''}`}
-        >
-          {pos}
-        </span>
-      </div>
-
       <div
-        className={`${styles.cell} ${styles.carNumberCell}`}
+        className={`${styles.cell} ${styles.posCell}`}
         style={{
           borderLeft: `3px solid ${driver.carClassColor}`,
           background: `linear-gradient(to right, ${driver.carClassColor}33, transparent)`,
         }}
       >
         <span
-          className={`${styles.carNumber} ${driver.isPlayer ? styles.carNumberPlayer : ''}`}
+          className={`${styles.posNumber} ${driver.isPlayer ? styles.posNumberPlayer : ''}`}
         >
-          {formattedCarNumber}
+          {pos}
         </span>
+      </div>
+
+      {settings.showPosChange && (
+        <div className={`${styles.cell} ${styles.cellCenter}`}>
+          <PosChange carIdx={carIdx} />
+        </div>
+      )}
+
+      <div className={`${styles.cell} ${styles.carNumberCell}`}>
+        <span className={styles.carNumber}>#{formattedCarNumber}</span>
       </div>
 
       <div className={`${styles.cell} ${styles.nameCell}`}>
@@ -159,12 +161,6 @@ export const DriverRow = observer(({ carIdx, index }: DriverRowProps) => {
       {settings.showLapsCompleted && (
         <div className={`${styles.cell} ${styles.cellCenter}`}>
           <span className={styles.lapsCompleted}>{driver.lap}</span>
-        </div>
-      )}
-
-      {settings.showPosChange && (
-        <div className={`${styles.cell} ${styles.cellCenter}`}>
-          <PosChange carIdx={carIdx} />
         </div>
       )}
 

--- a/src/widgets/StandingsWidget/SessionHeader/SessionHeader.module.scss
+++ b/src/widgets/StandingsWidget/SessionHeader/SessionHeader.module.scss
@@ -27,6 +27,22 @@
 }
 
 .sessionType {
+  font-weight: 700;
+}
+
+.sessionTypePractice {
+  color: $race-blue;
+}
+
+.sessionTypeQualify {
+  color: $race-purple;
+}
+
+.sessionTypeRace {
+  color: $race-green;
+}
+
+.sessionTypeOther {
   color: $widget-text-secondary;
 }
 

--- a/src/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
+++ b/src/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
@@ -14,6 +14,12 @@ import {
 
 import type { StandingsWidgetSettings } from '@/types/widget-settings';
 import styles from './SessionHeader.module.scss';
+import {
+  useBackendComputedStore,
+  useCarsStore,
+  useSessionStore,
+  useWidgetSettingsStore,
+} from '@store/root-store-context';
 
 const SESSION_TYPE_CLASS: Record<SessionColorKey, string> = {
   practice: styles.sessionTypePractice,
@@ -21,12 +27,6 @@ const SESSION_TYPE_CLASS: Record<SessionColorKey, string> = {
   race: styles.sessionTypeRace,
   other: styles.sessionTypeOther,
 };
-import {
-  useBackendComputedStore,
-  useCarsStore,
-  useSessionStore,
-  useWidgetSettingsStore,
-} from '@store/root-store-context';
 
 export const SessionHeader = observer(() => {
   const { standings } = useBackendComputedStore();

--- a/src/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
+++ b/src/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
@@ -7,9 +7,20 @@ import {
 } from '@utils/widget/widget-utils';
 import { resolveSessionLaps } from '@utils/formatters/telemetry-format';
 import { computeClassSof } from '@utils/widget/standings-utils';
+import {
+  resolveSessionColorKey,
+  type SessionColorKey,
+} from '@utils/widget/timer-utils';
 
 import type { StandingsWidgetSettings } from '@/types/widget-settings';
 import styles from './SessionHeader.module.scss';
+
+const SESSION_TYPE_CLASS: Record<SessionColorKey, string> = {
+  practice: styles.sessionTypePractice,
+  qualify: styles.sessionTypeQualify,
+  race: styles.sessionTypeRace,
+  other: styles.sessionTypeOther,
+};
 import {
   useBackendComputedStore,
   useCarsStore,
@@ -61,8 +72,10 @@ export const SessionHeader = observer(() => {
         {trackName && <span className={styles.trackName}>{trackName}</span>}
 
         {currentSession && (
-          <span className={styles.sessionType}>
-            {currentSession.sessionType.toUpperCase()}
+          <span
+            className={`${styles.sessionType} ${SESSION_TYPE_CLASS[resolveSessionColorKey(currentSession.sessionType)]}`}
+          >
+            {currentSession.sessionTypeLabel.toUpperCase()}
           </span>
         )}
 

--- a/src/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
+++ b/src/widgets/StandingsWidget/SessionHeader/SessionHeader.tsx
@@ -75,7 +75,9 @@ export const SessionHeader = observer(() => {
           <span
             className={`${styles.sessionType} ${SESSION_TYPE_CLASS[resolveSessionColorKey(currentSession.sessionType)]}`}
           >
-            {currentSession.sessionTypeLabel.toUpperCase()}
+            {(
+              currentSession.sessionTypeLabel ?? currentSession.sessionType
+            ).toUpperCase()}
           </span>
         )}
 

--- a/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.tsx
+++ b/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.tsx
@@ -24,6 +24,11 @@ export const StandingsHeader = observer(() => {
       style={{ gridTemplateColumns: gridTemplate }}
     >
       <StandingsHeaderCell>Pos</StandingsHeaderCell>
+
+      {settings.showPosChange && (
+        <StandingsHeaderCell align="center">+/-</StandingsHeaderCell>
+      )}
+
       <StandingsHeaderCell className={styles.carNumHeader}>
         #
       </StandingsHeaderCell>
@@ -48,10 +53,6 @@ export const StandingsHeader = observer(() => {
 
       {settings.showLapsCompleted && (
         <StandingsHeaderCell align="center">Laps</StandingsHeaderCell>
-      )}
-
-      {settings.showPosChange && (
-        <StandingsHeaderCell align="center">+/-</StandingsHeaderCell>
       )}
 
       <StandingsHeaderCell align="center">Gap</StandingsHeaderCell>

--- a/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.tsx
+++ b/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.tsx
@@ -35,7 +35,7 @@ export const StandingsHeader = observer(() => {
       <StandingsHeaderCell>Driver</StandingsHeaderCell>
 
       {settings.showLicBadge && (
-        <StandingsHeaderCell align="center">Lic</StandingsHeaderCell>
+        <StandingsHeaderCell align="center">SR</StandingsHeaderCell>
       )}
 
       {settings.showIRating && (
@@ -47,7 +47,7 @@ export const StandingsHeader = observer(() => {
           align="center"
           title="Projected iR change (Elo estimate, not real iRacing data)"
         >
-          ΔiR
+          ±iR
         </StandingsHeaderCell>
       )}
 

--- a/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.tsx
+++ b/src/widgets/StandingsWidget/StandingsHeader/StandingsHeader.tsx
@@ -26,7 +26,7 @@ export const StandingsHeader = observer(() => {
       <StandingsHeaderCell>Pos</StandingsHeaderCell>
 
       {settings.showPosChange && (
-        <StandingsHeaderCell align="center">+/-</StandingsHeaderCell>
+        <StandingsHeaderCell align="center">±</StandingsHeaderCell>
       )}
 
       <StandingsHeaderCell className={styles.carNumHeader}>


### PR DESCRIPTION
- **Class color indicator** moved from car number column to position column in both Standings and Relative; border flushes to the left edge of the widget
  - **Car number** (`#NNN`) text color changed to muted — class identity is now carried by the position column
  - **±  column** (position change) moved immediately after position, before car number, in both row and header
  - **Relative row height** aligned to match Standings (`sp(xs)` vertical padding, `fs(md)` font)
  - **Player row** highlight replaced with a center-out yellow gradient (`$widget-row-player-gradient` token); text stays white; off-track/pit state desaturates the gradient via `filter:
  grayscale`
  - **Session type label** in Standings header now uses `sessionTypeLabel` (matches Timer widget wording) and color-coded text: Race → green, Qualify → purple, Practice → blue
  - **Column header renames**: `Lic` → `SR`, `ΔiR` → `±iR`, `+/-` → `±`
  - Extracted `$widget-row-player-gradient` SCSS token to `_widget-tokens.scss`