### PR TITLE
feat(led-flags): redesign flag matrix animations, add split and single variants

### DIFF
--- a/src/app/main/components/WidgetSettings/panels/FlagDisplaySettingsPanel.tsx
+++ b/src/app/main/components/WidgetSettings/panels/FlagDisplaySettingsPanel.tsx
@@ -1,4 +1,4 @@
-﻿import { observer } from 'mobx-react-lite';
+import { observer } from 'mobx-react-lite';
 import { Slider, Switch } from 'antd';
 import { FlagDisplaySettings } from '@/types/widget-settings';
 import styles from '@app/main/components/WidgetSettings/WidgetSettings.module.scss';
@@ -48,6 +48,46 @@ export const FlagDisplaySettingsPanel = observer(
               onChange={(v) => update({ holdDuration: v })}
             />
           </div>
+        )}
+
+        {widgetId === 'led-flags' && (
+          <>
+            <div className={styles.fieldGroup}>
+              <SettingRow
+                title="Force Single LED"
+                desc="Show a single large indicator instead of the LED matrix."
+              >
+                <Switch
+                  checked={settings.forceSingleLed ?? false}
+                  onChange={(v) => update({ forceSingleLed: v })}
+                />
+              </SettingRow>
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <SettingRow
+                title="Split Display"
+                desc="Split matrix into left & right parts to place around mirror."
+              >
+                <Switch
+                  checked={settings.split ?? false}
+                  onChange={(v) => update({ split: v })}
+                />
+              </SettingRow>
+            </div>
+
+            <div className={styles.fieldGroup}>
+              <SettingRow
+                title="Animate LEDs"
+                desc="Enable dynamic scrolling and waving patterns for flags."
+              >
+                <Switch
+                  checked={settings.animate ?? true}
+                  onChange={(v) => update({ animate: v })}
+                />
+              </SettingRow>
+            </div>
+          </>
         )}
       </Card>
     );

--- a/src/store/widget-defaults.ts
+++ b/src/store/widget-defaults.ts
@@ -24,6 +24,7 @@ import type {
   StandingsWidgetSettings,
   RelativeWidgetSettings,
   InputTraceSettings,
+  FlagDisplaySettings,
 } from '@/types/widget-settings';
 import { computeStandingsDesignWidth } from '@utils/widget/standings-utils';
 import { computeRelativeDesignWidth } from '@utils/widget/relative-utils';
@@ -174,6 +175,40 @@ const resolveChassisLayout: ResolveLayoutChange = (prev, next, current) => {
     designWidth: nextShow
       ? CHASSIS_WITH_SUSPENSION_DESIGN_WIDTH
       : CHASSIS_DESIGN_WIDTH,
+    currentWidth: nextWidth,
+    userSettingsPatch: { modeWidths: savedModeWidths },
+  };
+};
+
+const resolveLedFlagsLayout: ResolveLayoutChange = (prev, next, current) => {
+  if (!('split' in next)) return null;
+
+  const prevSettings = prev as unknown as FlagDisplaySettings;
+  const nextSettings = next as unknown as FlagDisplaySettings;
+
+  const prevSplit = !!prevSettings.split;
+  const nextSplit = !!nextSettings.split;
+
+  if (prevSplit === nextSplit) return null;
+
+  const prevMode = prevSplit ? 'split' : 'single';
+  const nextMode = nextSplit ? 'split' : 'single';
+
+  const prevModeWidths =
+    'modeWidths' in prev
+      ? ((prev.modeWidths as Record<string, number>) ?? {})
+      : {};
+
+  const savedModeWidths: Record<string, number> = {
+    ...prevModeWidths,
+    [prevMode]: current.currentWidth,
+  };
+
+  const defaultNextWidth = nextSplit ? 696 : 232;
+  const nextWidth = savedModeWidths[nextMode] ?? defaultNextWidth;
+
+  return {
+    designWidth: nextSplit ? 696 : 232,
     currentWidth: nextWidth,
     userSettingsPatch: { modeWidths: savedModeWidths },
   };
@@ -472,6 +507,7 @@ const WIDGETS: WidgetConfig[] = [
     label: 'LED Flags',
     description: 'LED matrix display of track flags.',
     component: LedFlagWidget,
+    resolveLayoutChange: resolveLedFlagsLayout,
     designWidth: 232,
     designHeight: 232,
     userSettings: {
@@ -486,6 +522,9 @@ const WIDGETS: WidgetConfig[] = [
       hotkey: '',
       alwaysShow: true,
       holdDuration: 3,
+      split: false,
+      animate: true,
+      forceSingleLed: false,
     },
   },
   {

--- a/src/storybook/define-widget-stories.tsx
+++ b/src/storybook/define-widget-stories.tsx
@@ -88,7 +88,7 @@ export const defineWidgetStories = <Args,>(
       });
     }, [store, argsSignature]);
 
-    return <Widget />;
+    return <Widget {...(hostArgs as object)} />;
   };
 
   const frameDecorator: Decorator = (Story, context) => {

--- a/src/types/widget-settings.ts
+++ b/src/types/widget-settings.ts
@@ -161,6 +161,7 @@ export interface FlagDisplaySettings {
   split?: boolean;
   animate?: boolean;
   forceSingleLed?: boolean;
+  modeWidths?: Record<string, number>;
 }
 
 export interface ChassisWidgetSettings {

--- a/src/types/widget-settings.ts
+++ b/src/types/widget-settings.ts
@@ -158,6 +158,9 @@ export interface TimerWidgetSettings {
 export interface FlagDisplaySettings {
   alwaysShow: boolean;
   holdDuration: number;
+  split?: boolean;
+  animate?: boolean;
+  forceSingleLed?: boolean;
 }
 
 export interface ChassisWidgetSettings {

--- a/src/utils/widget/led-flag-utils.ts
+++ b/src/utils/widget/led-flag-utils.ts
@@ -30,23 +30,36 @@ export const computeDiodesPerBlock = (containerSize: number): number => {
   );
 };
 
-export const buildGridData = (dpb: number): BlockData[] => {
-  const blocks: BlockData[] = [];
-  const last = BLOCKS * dpb - 1;
+export const computeSplitRows = (containerHeight: number): number => {
+  const available = containerHeight - BOARD_PADDING_PX * 2;
+  return Math.max(3, Math.floor(available / DIODE_CELL_PX));
+};
 
-  for (let by = 0; by < BLOCKS; by++) {
-    for (let bx = 0; bx < BLOCKS; bx++) {
+export const buildGridData = (
+  dpbX: number,
+  dpbY: number,
+  widthBlocks: number = 3,
+  heightBlocks: number = 3,
+  split: boolean = false
+): BlockData[] => {
+  const blocks: BlockData[] = [];
+  const lastX = widthBlocks * dpbX - 1;
+  const lastY = heightBlocks * dpbY - 1;
+
+  for (let by = 0; by < heightBlocks; by++) {
+    for (let bx = 0; bx < widthBlocks; bx++) {
       const diodes: DiodeData[] = [];
 
-      for (let dy = 0; dy < dpb; dy++) {
-        for (let dx = 0; dx < dpb; dx++) {
-          const gx = bx * dpb + dx;
-          const gy = by * dpb + dy;
+      for (let dy = 0; dy < dpbY; dy++) {
+        for (let dx = 0; dx < dpbX; dx++) {
+          const gx = bx * dpbX + dx;
+          const gy = by * dpbY + dy;
           const isCorner =
-            (gx === 0 && gy === 0) ||
-            (gx === last && gy === 0) ||
-            (gx === 0 && gy === last) ||
-            (gx === last && gy === last);
+            !split &&
+            ((gx === 0 && gy === 0) ||
+              (gx === lastX && gy === 0) ||
+              (gx === 0 && gy === lastY) ||
+              (gx === lastX && gy === lastY));
 
           diodes.push({ gx, gy, bx, by, isCorner, key: `${gx}-${gy}` });
         }

--- a/src/widgets/LedFlagWidget/LedFlagWidget.module.scss
+++ b/src/widgets/LedFlagWidget/LedFlagWidget.module.scss
@@ -47,3 +47,20 @@
     0 0 4px $led-orange,
     0 0 8px $led-orange;
 }
+
+.splitWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 100%;
+}
+
+.leftSlot,
+.rightSlot {
+  display: flex;
+  height: 100%;
+  aspect-ratio: 1 / 3;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/widgets/LedFlagWidget/LedFlagWidget.stories.tsx
+++ b/src/widgets/LedFlagWidget/LedFlagWidget.stories.tsx
@@ -4,7 +4,9 @@ import type { FlagType } from '@/types';
 import { LedFlagWidget } from './LedFlagWidget';
 import { defineWidgetStories } from '@/storybook/define-widget-stories';
 
-const DESIGN_SIZE = 160;
+import type { FlagDisplaySettings } from '@/types/widget-settings';
+
+const DESIGN_SIZE = 300;
 
 const ALL_FLAGS: FlagType[] = [
   'none',
@@ -21,6 +23,9 @@ const ALL_FLAGS: FlagType[] = [
 
 interface StoryArgs {
   flag: FlagType;
+  split: boolean;
+  animate: boolean;
+  forceSingleLed?: boolean;
 }
 
 const meta: Meta<StoryArgs> = {
@@ -30,10 +35,21 @@ const meta: Meta<StoryArgs> = {
     size: { width: DESIGN_SIZE, height: DESIGN_SIZE, background: '#111' },
     seed: (store, args) => {
       store.flags.ledDisplayFlag = args.flag;
+      const settings =
+        store.widgetSettings.getSettings<FlagDisplaySettings>('led-flags');
+      store.widgetSettings.updateUserSettings('led-flags', {
+        ...settings,
+        split: args.split,
+        animate: args.animate,
+        forceSingleLed: args.forceSingleLed,
+      });
     },
-    args: { flag: 'none' },
+    args: { flag: 'none', split: false, animate: true, forceSingleLed: false },
     argTypes: {
       flag: { control: 'select', options: ALL_FLAGS },
+      split: { control: 'boolean' },
+      animate: { control: 'boolean' },
+      forceSingleLed: { control: 'boolean' },
     },
   }),
 };
@@ -52,3 +68,45 @@ export const CheckeredFlag: Story = { args: { flag: 'checkered' } };
 export const BlackFlag: Story = { args: { flag: 'black' } };
 export const MeatballFlag: Story = { args: { flag: 'meatball' } };
 export const DebrisFlag: Story = { args: { flag: 'debris' } };
+
+export const SplitAnimated: Story = {
+  args: { flag: 'yellow', split: true, animate: true },
+  parameters: {
+    widgetFrame: { width: 900, height: 300 },
+  },
+};
+
+export const SplitRedFlagAnimated: Story = {
+  args: { flag: 'red', split: true, animate: true },
+  parameters: {
+    widgetFrame: { width: 900, height: 300 },
+  },
+};
+
+export const SmallRedFlagAnimated: Story = {
+  args: { flag: 'red', split: false, animate: true },
+  parameters: {
+    widgetFrame: { width: 200, height: 200 },
+  },
+};
+
+export const MediumRedFlagAnimated: Story = {
+  args: { flag: 'red', split: false, animate: true },
+  parameters: {
+    widgetFrame: { width: 350, height: 350 },
+  },
+};
+
+export const LargeMatrixRedFlag: Story = {
+  args: { flag: 'red', split: false, animate: true },
+  parameters: {
+    widgetFrame: { width: 600, height: 600 },
+  },
+};
+
+export const SingleLedMax: Story = {
+  args: { flag: 'red', split: false, animate: true, forceSingleLed: true },
+  parameters: {
+    widgetFrame: { width: 600, height: 600 },
+  },
+};

--- a/src/widgets/LedFlagWidget/LedFlagWidget.tsx
+++ b/src/widgets/LedFlagWidget/LedFlagWidget.tsx
@@ -4,17 +4,24 @@ import { observer } from 'mobx-react-lite';
 import {
   MIN_SINGLE_LED_PX,
   computeDiodesPerBlock,
+  computeSplitRows,
 } from '@utils/widget/led-flag-utils';
 import { SingleLed } from './SingleLed/SingleLed';
 import { LedMatrix } from './LedMatrix/LedMatrix';
+import { useWidgetSettingsStore } from '@store/root-store-context';
+import type { FlagDisplaySettings } from '@/types/widget-settings';
 
 import styles from './LedFlagWidget.module.scss';
 
 export const LedFlagWidget = observer(() => {
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const widgetSettings = useWidgetSettingsStore();
+  const { split, forceSingleLed } =
+    widgetSettings.getSettings<FlagDisplaySettings>('led-flags');
 
   const [layout, setLayout] = useState({
     diodesPerBlock: 6,
+    splitRows: 18,
     isSingleLed: false,
   });
 
@@ -26,10 +33,9 @@ export const LedFlagWidget = observer(() => {
     }
 
     const obs = new ResizeObserver(([entry]) => {
-      const smallestSide = Math.min(
-        entry.contentRect.width,
-        entry.contentRect.height
-      );
+      const smallestSide = split
+        ? entry.contentRect.height
+        : Math.min(entry.contentRect.width, entry.contentRect.height);
 
       if (smallestSide < MIN_SINGLE_LED_PX) {
         setLayout((prev) =>
@@ -37,11 +43,18 @@ export const LedFlagWidget = observer(() => {
         );
       } else {
         const nextDiodes = computeDiodesPerBlock(smallestSide);
+        const nextSplitRows = computeSplitRows(entry.contentRect.height);
 
         setLayout((prev) =>
-          !prev.isSingleLed && prev.diodesPerBlock === nextDiodes
+          !prev.isSingleLed &&
+          prev.diodesPerBlock === nextDiodes &&
+          prev.splitRows === nextSplitRows
             ? prev
-            : { isSingleLed: false, diodesPerBlock: nextDiodes }
+            : {
+                isSingleLed: false,
+                diodesPerBlock: nextDiodes,
+                splitRows: nextSplitRows,
+              }
         );
       }
     });
@@ -49,14 +62,29 @@ export const LedFlagWidget = observer(() => {
     obs.observe(el);
 
     return () => obs.disconnect();
-  }, []);
+  }, [split]);
+
+  const renderContent = () => {
+    if (forceSingleLed || layout.isSingleLed) {
+      return <SingleLed />;
+    }
+    return (
+      <LedMatrix
+        diodesPerBlock={layout.diodesPerBlock}
+        splitRows={layout.splitRows}
+      />
+    );
+  };
 
   return (
     <div ref={wrapperRef} className={styles.wrapper}>
-      {layout.isSingleLed ? (
-        <SingleLed />
+      {split ? (
+        <div className={styles.splitWrapper}>
+          <div className={styles.leftSlot}>{renderContent()}</div>
+          <div className={styles.rightSlot}>{renderContent()}</div>
+        </div>
       ) : (
-        <LedMatrix diodesPerBlock={layout.diodesPerBlock} />
+        renderContent()
       )}
     </div>
   );

--- a/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
+++ b/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
@@ -117,6 +117,10 @@ $board-padding: 4px;
   &.flag-black .colorWhite {
     animation: ledBlackBorderFlash 0.8s infinite steps(1);
   }
+
+  &.flag-white .colorWhite {
+    animation: ledWhiteBreathing 2s infinite ease-in-out;
+  }
 }
 
 @keyframes ledYellowAlternating {
@@ -204,6 +208,16 @@ $board-padding: 4px;
   50%,
   100% {
     background-color: $led-surface-panel;
+  }
+}
+
+@keyframes ledWhiteBreathing {
+  0%,
+  100% {
+    background-color: $led-white;
+  }
+  50% {
+    background-color: color-mix(in srgb, $led-white 50%, $led-surface-panel);
   }
 }
 

--- a/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
+++ b/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
@@ -10,31 +10,22 @@ $board-padding: 4px;
   border-radius: 6px;
   display: grid;
   grid-template-columns: repeat(
-    var(--blocks),
+    var(--blocks-x, var(--blocks)),
     calc(var(--dpb) * #{$diode-cell})
   );
-  gap: $block-gap;
+  gap: var(--board-gap, #{$block-gap});
   position: relative;
 }
 
-.glassOverlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 0.05) 0%,
-    transparent 40%
-  );
-  pointer-events: none;
-  z-index: 10;
-  border-radius: 6px;
+.animate {
+  visibility: visible;
 }
 
 .block {
   background-color: $led-surface-matrix;
   display: grid;
-  grid-template-columns: repeat(var(--dpb), #{$diode-cell});
-  grid-template-rows: repeat(var(--dpb), #{$diode-cell});
+  grid-template-columns: repeat(var(--dpb-x, var(--dpb)), #{$diode-cell});
+  grid-template-rows: repeat(var(--dpb-y, var(--dpb)), #{$diode-cell});
 }
 
 .diode {
@@ -52,46 +43,240 @@ $board-padding: 4px;
   visibility: hidden;
 }
 
-// Color classes are intentionally duplicated in SingleLed.module.scss —
-// CSS Modules scope prevents sharing, and local definition avoids background override.
 .colorGreen {
   background-color: $led-green;
-  box-shadow:
-    0 0 4px $led-green,
-    0 0 8px $led-green;
 }
 
 .colorYellow {
   background-color: $led-yellow;
-  box-shadow:
-    0 0 4px $led-yellow,
-    0 0 8px $led-yellow;
+}
+
+.colorYellowStatic {
+  background-color: $led-yellow;
 }
 
 .colorRed {
   background-color: $led-red;
-  box-shadow:
-    0 0 4px $led-red,
-    0 0 8px $led-red;
 }
 
 .colorBlue {
   background-color: $led-blue;
-  box-shadow:
-    0 0 4px $led-blue,
-    0 0 8px $led-blue;
 }
 
 .colorWhite {
   background-color: $led-white;
-  box-shadow:
-    0 0 4px $led-white,
-    0 0 8px rgba($led-white, 0.6);
 }
 
 .colorOrange {
   background-color: $led-orange;
-  box-shadow:
-    0 0 4px $led-orange,
-    0 0 8px $led-orange;
+}
+
+.board.flag-checkered .colorWhite {
+  background-color: color-mix(
+    in srgb,
+    $led-white calc((1 - var(--checkered-parity)) * 100%),
+    $led-surface-panel
+  );
+}
+
+.board.animate {
+  &.flag-yellow .colorYellow {
+    animation: ledYellowAlternating 1s infinite steps(1);
+    animation-delay: calc(var(--col-parity) * 0.5s);
+  }
+
+  &.flag-blue {
+    .colorBlue {
+      animation: ledBlueScroll 1s infinite steps(1);
+    }
+    .colorYellow {
+      animation: ledYellowScrollBlue 1s infinite steps(1);
+    }
+  }
+
+  &.flag-checkered .colorWhite {
+    animation: ledCheckeredAlternating 1s infinite steps(1);
+    animation-delay: calc(var(--checkered-parity) * 0.5s);
+  }
+
+  &.flag-debris {
+    .colorYellow {
+      animation: ledYellowScrollRed 1s infinite steps(1);
+    }
+    .colorRed {
+      animation: ledRedScrollYellow 1s infinite steps(1);
+    }
+  }
+
+  &.flag-meatball {
+    .colorOrange {
+      animation: ledMeatballBlink 1s infinite steps(1);
+    }
+  }
+
+  &.flag-black .colorWhite {
+    animation: ledBlackBorderFlash 0.8s infinite steps(1);
+  }
+}
+
+@keyframes ledYellowAlternating {
+  0%,
+  49.99% {
+    background-color: $led-yellow;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes ledBlueScroll {
+  0%,
+  49.99% {
+    background-color: $led-blue;
+  }
+  50%,
+  100% {
+    background-color: $led-yellow;
+  }
+}
+
+@keyframes ledYellowScrollBlue {
+  0%,
+  49.99% {
+    background-color: $led-yellow;
+  }
+  50%,
+  100% {
+    background-color: $led-blue;
+  }
+}
+
+@keyframes ledCheckeredAlternating {
+  0%,
+  49.99% {
+    background-color: $led-white;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes ledYellowScrollRed {
+  0%,
+  49.99% {
+    background-color: $led-yellow;
+  }
+  50%,
+  100% {
+    background-color: $led-red;
+  }
+}
+
+@keyframes ledRedScrollYellow {
+  0%,
+  49.99% {
+    background-color: $led-red;
+  }
+  50%,
+  100% {
+    background-color: $led-yellow;
+  }
+}
+
+@keyframes ledMeatballBlink {
+  0%,
+  49.99% {
+    background-color: $led-orange;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes ledBlackBorderFlash {
+  0%,
+  49.99% {
+    background-color: $led-white;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+.flag-red {
+  visibility: visible;
+}
+
+.board.animate.flag-red {
+  .diode[data-is-outer='true'],
+  .diode[data-is-center='true'] {
+    animation: ledRedStateA 1s infinite steps(1);
+  }
+
+  .diode[data-is-inner='true'] {
+    animation: ledRedStateB 1s infinite steps(1);
+  }
+}
+
+@keyframes ledRedStateA {
+  0%,
+  49.99% {
+    background-color: $led-red;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes ledRedStateB {
+  0%,
+  49.99% {
+    background-color: $led-surface-panel;
+  }
+  50%,
+  100% {
+    background-color: $led-red;
+  }
+}
+
+.flag-green {
+  visibility: visible;
+}
+
+@for $max-r from 0 through 12 {
+  $steps: $max-r + 4;
+
+  @for $r from 0 through $max-r {
+    .board.animate.flag-green[data-max-ring='#{$max-r}']
+      .colorGreen[data-ring='#{$r}'] {
+      animation: ledGreenFill-#{$max-r}-#{$r} 1s infinite steps(1);
+    }
+
+    @keyframes ledGreenFill-#{$max-r}-#{$r} {
+      @for $s from 0 through $steps {
+        $pct: ($s / $steps) * 100%;
+
+        $is-on: false;
+        @if $s < $max-r {
+          $pos: $max-r - $s;
+          @if $r >= $pos {
+            $is-on: true;
+          }
+        } @else if $s < $max-r + 2 {
+          $is-on: true;
+        } @else {
+          $is-on: false;
+        }
+
+        #{$pct} {
+          background-color: if($is-on, $led-green, $led-surface-panel);
+        }
+      }
+    }
+  }
 }

--- a/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.tsx
+++ b/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.tsx
@@ -48,9 +48,12 @@ export const LedMatrix = observer(
 
     const checkerSize = dpbX >= 8 ? 3 : dpbX >= 6 ? 2 : 1;
 
-    const maxRing = split
-      ? Math.floor((matrixSizeY - 1) / 2)
-      : Math.floor((Math.min(matrixSizeX, matrixSizeY) - 1) / 2);
+    const maxRing = Math.min(
+      12,
+      split
+        ? Math.floor((matrixSizeY - 1) / 2)
+        : Math.floor((Math.min(matrixSizeX, matrixSizeY) - 1) / 2)
+    );
 
     return (
       <div
@@ -91,9 +94,12 @@ export const LedMatrix = observer(
                     styles as unknown as ColorStyles
                   );
 
-              const ring = split
-                ? Math.min(gy, matrixSizeY - 1 - gy)
-                : Math.min(gx, gy, matrixSizeX - 1 - gx, matrixSizeY - 1 - gy);
+              const ring = Math.min(
+                maxRing,
+                split
+                  ? Math.min(gy, matrixSizeY - 1 - gy)
+                  : Math.min(gx, gy, matrixSizeX - 1 - gx, matrixSizeY - 1 - gy)
+              );
               const cx = matrixSizeX / 2 - 0.5;
               const cy = matrixSizeY / 2 - 0.5;
               const distCenter = Math.sqrt((gx - cx) ** 2 + (gy - cy) ** 2);
@@ -110,7 +116,7 @@ export const LedMatrix = observer(
                 (split
                   ? ring >= maxRing - 4 && ring < maxRing - 1
                   : ring >= dpbX - 3 && ring < dpbX);
-              const isOuter = !isCenter && !isInner && ring <= 2;
+              const isOuter = !isCenter && !isInner;
 
               const chevronVal = gy - Math.abs(gx - cx);
               const chevronParity = Math.floor((chevronVal + 100) / 3) % 2;

--- a/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.tsx
+++ b/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.tsx
@@ -12,60 +12,139 @@ import {
 
 interface LedMatrixProps {
   diodesPerBlock: number;
+  splitRows?: number;
 }
 
-export const LedMatrix = observer(({ diodesPerBlock }: LedMatrixProps) => {
-  const flags = useFlagsStore();
-  const widgetSettings = useWidgetSettingsStore();
-  const { alwaysShow } =
-    widgetSettings.getSettings<FlagDisplaySettings>('led-flags');
-  const { ledDisplayFlag: flag, blinkOn } = flags;
+export const LedMatrix = observer(
+  ({ diodesPerBlock, splitRows = 18 }: LedMatrixProps) => {
+    const flags = useFlagsStore();
+    const widgetSettings = useWidgetSettingsStore();
+    const { alwaysShow, animate, split } =
+      widgetSettings.getSettings<FlagDisplaySettings>('led-flags');
+    const { ledDisplayFlag: flag, blinkOn } = flags;
 
-  if (!alwaysShow && flag === 'none') {
-    return null;
+    if (!alwaysShow && flag === 'none') {
+      return null;
+    }
+
+    const isOff =
+      flag === 'none' ||
+      (!animate && (flag === 'yellow' || flag === 'red') && !blinkOn);
+
+    const dpbX = split ? 3 : diodesPerBlock;
+    const dpbY = split ? splitRows : diodesPerBlock;
+    const widthBlocks = split ? 1 : BLOCKS;
+    const heightBlocks = split ? 1 : BLOCKS;
+
+    const gridData = buildGridData(
+      dpbX,
+      dpbY,
+      widthBlocks,
+      heightBlocks,
+      !!split
+    );
+    const matrixSizeX = widthBlocks * dpbX;
+    const matrixSizeY = heightBlocks * dpbY;
+
+    const checkerSize = dpbX >= 8 ? 3 : dpbX >= 6 ? 2 : 1;
+
+    const maxRing = split
+      ? Math.floor((matrixSizeY - 1) / 2)
+      : Math.floor((Math.min(matrixSizeX, matrixSizeY) - 1) / 2);
+
+    return (
+      <div
+        className={`${styles.board}${animate ? ` ${styles.animate}` : ''} ${styles[`flag-${flag}`] || ''}`}
+        data-size={dpbX >= 8 && !split ? 'large' : 'small'}
+        data-max-ring={maxRing}
+        style={
+          {
+            '--dpb': dpbX,
+            '--dpb-x': dpbX,
+            '--dpb-y': dpbY,
+            '--blocks': heightBlocks,
+            '--blocks-x': widthBlocks,
+            '--board-gap': split ? '0px' : undefined,
+            '--max-ring': maxRing,
+            '--wave-width': dpbX >= 8 && !split ? 1.5 : 0.5,
+            '--max-radius': Math.min(matrixSizeX, matrixSizeY) * 0.38,
+          } as React.CSSProperties
+        }
+      >
+        {gridData.map(({ diodes, key }) => (
+          <div key={key} className={styles.block}>
+            {diodes.map(({ gx, gy, bx, by, isCorner, key: dk }) => {
+              if (isCorner) {
+                return <div key={dk} className={styles.diodeHidden} />;
+              }
+
+              const colorClass = isOff
+                ? ''
+                : getColorClass(
+                    gx,
+                    gy,
+                    bx,
+                    by,
+                    flag,
+                    matrixSizeX,
+                    matrixSizeY,
+                    styles as unknown as ColorStyles
+                  );
+
+              const ring = split
+                ? Math.min(gy, matrixSizeY - 1 - gy)
+                : Math.min(gx, gy, matrixSizeX - 1 - gx, matrixSizeY - 1 - gy);
+              const cx = matrixSizeX / 2 - 0.5;
+              const cy = matrixSizeY / 2 - 0.5;
+              const distCenter = Math.sqrt((gx - cx) ** 2 + (gy - cy) ** 2);
+              const colParity = gx < cx ? 0 : 1;
+              const checkeredParity =
+                (Math.floor(gx / checkerSize) + Math.floor(gy / checkerSize)) %
+                2;
+
+              const isCenter = split
+                ? ring >= maxRing - 1
+                : bx === 1 && by === 1;
+              const isInner =
+                !isCenter &&
+                (split
+                  ? ring >= maxRing - 4 && ring < maxRing - 1
+                  : ring >= dpbX - 3 && ring < dpbX);
+              const isOuter = !isCenter && !isInner && ring <= 2;
+
+              const chevronVal = gy - Math.abs(gx - cx);
+              const chevronParity = Math.floor((chevronVal + 100) / 3) % 2;
+
+              return (
+                <div
+                  key={dk}
+                  className={`${styles.diode}${colorClass ? ` ${colorClass}` : ''}`}
+                  data-ring={ring}
+                  data-is-center={isCenter}
+                  data-is-inner={isInner}
+                  data-is-outer={isOuter}
+                  style={
+                    {
+                      '--gx': gx,
+                      '--gy': gy,
+                      '--bx': bx,
+                      '--by': by,
+                      '--diag-parity': (gx + gy) % 2,
+                      '--col-parity': colParity,
+                      '--col-offset': (gx * 3) % 7,
+                      '--checkered-parity': checkeredParity,
+                      '--ring': ring,
+                      '--dist-center': distCenter,
+                      '--chevron-val': chevronVal,
+                      '--chevron-parity': chevronParity,
+                    } as React.CSSProperties
+                  }
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    );
   }
-
-  const isOff =
-    flag === 'none' || ((flag === 'yellow' || flag === 'red') && !blinkOn);
-
-  const gridData = buildGridData(diodesPerBlock);
-  const matrixSize = BLOCKS * diodesPerBlock;
-
-  return (
-    <div
-      className={styles.board}
-      style={{ '--dpb': diodesPerBlock, '--blocks': BLOCKS } as object}
-    >
-      {gridData.map(({ diodes, key }) => (
-        <div key={key} className={styles.block}>
-          {diodes.map(({ gx, gy, bx, by, isCorner, key: dk }) => {
-            if (isCorner) {
-              return <div key={dk} className={styles.diodeHidden} />;
-            }
-
-            const colorClass = isOff
-              ? ''
-              : getColorClass(
-                  gx,
-                  gy,
-                  bx,
-                  by,
-                  flag,
-                  matrixSize,
-                  styles as unknown as ColorStyles
-                );
-
-            return (
-              <div
-                key={dk}
-                className={`${styles.diode}${colorClass ? ` ${colorClass}` : ''}`}
-              />
-            );
-          })}
-        </div>
-      ))}
-
-      <div className={styles.glassOverlay} aria-hidden="true" />
-    </div>
-  );
-});
+);

--- a/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
+++ b/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
@@ -9,6 +9,10 @@
   position: relative;
 }
 
+.animate {
+  visibility: visible;
+}
+
 .singleLedInner {
   position: absolute;
   inset: 8px;
@@ -20,42 +24,101 @@
 // CSS Modules scope prevents sharing, and local definition avoids background override.
 .colorGreen {
   background-color: $led-green;
-  box-shadow:
-    0 0 4px $led-green,
-    0 0 8px $led-green;
 }
 
 .colorYellow {
   background-color: $led-yellow;
-  box-shadow:
-    0 0 4px $led-yellow,
-    0 0 8px $led-yellow;
 }
 
 .colorRed {
   background-color: $led-red;
-  box-shadow:
-    0 0 4px $led-red,
-    0 0 8px $led-red;
 }
 
 .colorBlue {
   background-color: $led-blue;
-  box-shadow:
-    0 0 4px $led-blue,
-    0 0 8px $led-blue;
 }
 
 .colorWhite {
   background-color: $led-white;
-  box-shadow:
-    0 0 4px $led-white,
-    0 0 8px rgba($led-white, 0.6);
 }
 
 .colorOrange {
   background-color: $led-orange;
-  box-shadow:
-    0 0 4px $led-orange,
-    0 0 8px $led-orange;
+}
+
+.singleLed.animate {
+  .colorGreen {
+    animation: singleGreenPulse 1s infinite steps(1);
+  }
+
+  .colorYellow {
+    animation: singleYellowPulse 1s infinite steps(1);
+  }
+
+  .colorRed {
+    animation: singleRedPulse 1s infinite steps(1);
+  }
+
+  .colorBlue {
+    animation: singleBluePulse 1s infinite steps(1);
+  }
+
+  .colorOrange {
+    animation: singleOrangePulse 1s infinite steps(1);
+  }
+}
+
+@keyframes singleGreenPulse {
+  0%,
+  49.99% {
+    background-color: $led-green;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes singleYellowPulse {
+  0%,
+  49.99% {
+    background-color: $led-yellow;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes singleRedPulse {
+  0%,
+  49.99% {
+    background-color: $led-red;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes singleBluePulse {
+  0%,
+  49.99% {
+    background-color: $led-blue;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
+}
+
+@keyframes singleOrangePulse {
+  0%,
+  49.99% {
+    background-color: $led-orange;
+  }
+  50%,
+  100% {
+    background-color: $led-surface-panel;
+  }
 }

--- a/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
+++ b/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
@@ -66,6 +66,10 @@
   .colorOrange {
     animation: singleOrangePulse 1s infinite steps(1);
   }
+
+  .colorWhite {
+    animation: singleWhiteBreathing 2s infinite ease-in-out;
+  }
 }
 
 @keyframes singleGreenPulse {
@@ -120,5 +124,15 @@
   50%,
   100% {
     background-color: $led-surface-panel;
+  }
+}
+
+@keyframes singleWhiteBreathing {
+  0%,
+  100% {
+    background-color: $led-white;
+  }
+  50% {
+    background-color: color-mix(in srgb, $led-white 50%, $led-surface-panel);
   }
 }

--- a/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
+++ b/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
@@ -46,6 +46,24 @@
   background-color: $led-orange;
 }
 
+.colorCheckered {
+  background: repeating-conic-gradient(
+      $led-surface-panel 0 25%,
+      $led-white 0 50%
+    )
+    0 0 / 20px 20px;
+}
+
+.colorDebris {
+  background: repeating-linear-gradient(
+    45deg,
+    $led-yellow,
+    $led-yellow 12px,
+    $led-red 12px,
+    $led-red 24px
+  );
+}
+
 .singleLed.animate {
   .colorGreen {
     animation: singleGreenPulse 1s infinite steps(1);
@@ -69,6 +87,14 @@
 
   .colorWhite {
     animation: singleWhiteBreathing 2s infinite ease-in-out;
+  }
+
+  .colorCheckered {
+    animation: singleCheckeredBlink 1s infinite steps(1);
+  }
+
+  .colorDebris {
+    animation: singleDebrisAlternating 1s infinite steps(1);
   }
 }
 
@@ -134,5 +160,37 @@
   }
   50% {
     background-color: color-mix(in srgb, $led-white 50%, $led-surface-panel);
+  }
+}
+
+@keyframes singleCheckeredBlink {
+  0%,
+  49.99% {
+    background: repeating-conic-gradient(
+        $led-surface-panel 0 25%,
+        $led-white 0 50%
+      )
+      0 0 / 20px 20px;
+  }
+  50%,
+  100% {
+    background: $led-surface-panel;
+  }
+}
+
+@keyframes singleDebrisAlternating {
+  0%,
+  49.99% {
+    background: repeating-linear-gradient(
+      45deg,
+      $led-yellow,
+      $led-yellow 12px,
+      $led-red 12px,
+      $led-red 24px
+    );
+  }
+  50%,
+  100% {
+    background: $led-surface-panel;
   }
 }

--- a/src/widgets/LedFlagWidget/SingleLed/SingleLed.tsx
+++ b/src/widgets/LedFlagWidget/SingleLed/SingleLed.tsx
@@ -13,7 +13,7 @@ export const SingleLed = observer(() => {
   const flags = useFlagsStore();
   const widgetSettings = useWidgetSettingsStore();
 
-  const { alwaysShow } =
+  const { alwaysShow, animate } =
     widgetSettings.getSettings<FlagDisplaySettings>('led-flags');
 
   const { ledDisplayFlag: flag, blinkOn } = flags;
@@ -23,14 +23,17 @@ export const SingleLed = observer(() => {
   }
 
   const isOff =
-    flag === 'none' || ((flag === 'yellow' || flag === 'red') && !blinkOn);
+    flag === 'none' ||
+    (!animate && (flag === 'yellow' || flag === 'red') && !blinkOn);
 
   const colorClass = isOff
     ? ''
     : getSingleLedColorClass(flag, styles as unknown as ColorStyles);
 
   return (
-    <div className={styles.singleLed}>
+    <div
+      className={`${styles.singleLed}${animate ? ` ${styles.animate}` : ''}`}
+    >
       <div
         className={`${styles.singleLedInner}${colorClass ? ` ${colorClass}` : ''}`}
       />

--- a/src/widgets/LedFlagWidget/led-matrix-utils.ts
+++ b/src/widgets/LedFlagWidget/led-matrix-utils.ts
@@ -9,6 +9,8 @@ export interface ColorStyles {
   colorWhite: string;
   colorBlue: string;
   colorOrange: string;
+  colorCheckered?: string;
+  colorDebris?: string;
 }
 
 export const getColorClass = (
@@ -87,14 +89,15 @@ export const getSingleLedColorClass = (
     case 'red':
       return styles.colorRed;
     case 'white':
-    case 'checkered':
       return styles.colorWhite;
+    case 'checkered':
+      return styles.colorCheckered || styles.colorWhite;
     case 'blue':
       return styles.colorBlue;
     case 'meatball':
       return styles.colorOrange;
     case 'debris':
-      return styles.colorYellow;
+      return styles.colorDebris || styles.colorYellow;
     default:
       return '';
   }

--- a/src/widgets/LedFlagWidget/led-matrix-utils.ts
+++ b/src/widgets/LedFlagWidget/led-matrix-utils.ts
@@ -4,6 +4,7 @@ import { BLOCKS } from '@utils/widget/led-flag-utils';
 export interface ColorStyles {
   colorGreen: string;
   colorYellow: string;
+  colorYellowStatic: string;
   colorRed: string;
   colorWhite: string;
   colorBlue: string;
@@ -13,22 +14,29 @@ export interface ColorStyles {
 export const getColorClass = (
   gx: number,
   gy: number,
-  bx: number,
-  by: number,
+  _bx: number,
+  _by: number,
   flag: FlagType,
-  matrixSize: number,
+  matrixSizeX: number,
+  matrixSizeY: number,
   styles: ColorStyles
 ): string => {
-  const last = matrixSize - 1;
-  const isEdge = gx === 0 || gx === last || gy === 0 || gy === last;
-  const dpb = matrixSize / BLOCKS;
+  const lastX = matrixSizeX - 1;
+  const lastY = matrixSizeY - 1;
+  const isEdge = gx === 0 || gx === lastX || gy === 0 || gy === lastY;
+  const dpb = matrixSizeY / BLOCKS;
 
   switch (flag) {
     case 'green':
       return styles.colorGreen;
 
-    case 'yellow':
+    case 'yellow': {
+      const midX = matrixSizeX / 2 - 0.5;
+      if (Math.abs(gx - midX) < 0.8) {
+        return styles.colorYellowStatic;
+      }
       return styles.colorYellow;
+    }
 
     case 'red':
       return styles.colorRed;
@@ -42,10 +50,10 @@ export const getColorClass = (
         : styles.colorYellow;
 
     case 'checkered':
-      return (bx + by) % 2 === 0 ? styles.colorWhite : '';
+      return styles.colorWhite;
 
     case 'debris':
-      return Math.floor(gx / 3) % 2 === 0
+      return Math.floor((gx + gy) / 3) % 2 === 0
         ? styles.colorYellow
         : styles.colorRed;
 
@@ -54,9 +62,9 @@ export const getColorClass = (
 
     case 'meatball': {
       if (isEdge) return styles.colorWhite;
-      const cx = matrixSize / 2 - 0.5;
-      const cy = matrixSize / 2 - 0.5;
-      const radiusSq = Math.pow(matrixSize * 0.38, 2);
+      const cx = matrixSizeX / 2 - 0.5;
+      const cy = matrixSizeY / 2 - 0.5;
+      const radiusSq = Math.pow(Math.min(matrixSizeX, matrixSizeY) * 0.38, 2);
       const dx = gx - cx;
       const dy = gy - cy;
       return dx * dx + dy * dy <= radiusSq ? styles.colorOrange : '';


### PR DESCRIPTION
 Refactored the LED Matrix and Single LED flag widget logic to improve visibility, styling, and animations in both standard and       
  split/single layout modes.

    Key changes:
    1. Red Matrix Flag:
       - Replaced static Sass loops with dynamic CSS state keyframes.
       - Introduced JS calculation for diode roles: isCenter (strictly covers the central 3x3 block in non-split mode), isInner (contour 
  of 3 diodes wrapping around the center block), and isOuter (contour of 3 diodes at the edges).
       - Changed red flag to alternate sharply between State A (outer + center ON) and State B (inner ON) on a 1.0s cycle.

    2. Green Matrix Flag:
       - Designed a center-to-edge expanding fill animation that fills the entire square with green, holds, and flashes off before       
  repeating.
       - Implemented using keyframes dynamically generated for each ring index so that inner rings stay ON as the wave moves outwards,   
  eliminating the "hole in the center."

    3. Split-Mode Improvements:
       - Updated the ring index calculation in split-mode to run vertically instead of radially. Both red and green animations now       
  propagate symmetrically from the horizontal center line outwards.

    4. Single LED Flag:
       - Added support for animations/blinking in Single LED mode for green, yellow, red, blue, and orange flags (they now blink at a 1. 
  0s interval instead of staying static).
       - Fixed static state evaluation when the `animate` setting is disabled.

    5. Storybook:
       - Added new widget test cases representing Split, Small (200x200), and Medium (350x350) sizes for the Red Flag to verify design   
  scaling.