### PR TITLE
fix(led-flags): remove visibility:visible overrides that broke auto-hide

### DIFF
--- a/src/widgets/LedFlagWidget/LedFlagWidget.tsx
+++ b/src/widgets/LedFlagWidget/LedFlagWidget.tsx
@@ -8,7 +8,11 @@ import {
 } from '@utils/widget/led-flag-utils';
 import { SingleLed } from './SingleLed/SingleLed';
 import { LedMatrix } from './LedMatrix/LedMatrix';
-import { useWidgetSettingsStore } from '@store/root-store-context';
+import {
+  useWidgetSettingsStore,
+  useFlagsStore,
+} from '@store/root-store-context';
+import { useWidgetAutoHide } from '@hooks/common/useWidgetAutoHide';
 import type { FlagDisplaySettings } from '@/types/widget-settings';
 
 import styles from './LedFlagWidget.module.scss';
@@ -16,8 +20,13 @@ import styles from './LedFlagWidget.module.scss';
 export const LedFlagWidget = observer(() => {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const widgetSettings = useWidgetSettingsStore();
-  const { split, forceSingleLed } =
+  const flags = useFlagsStore();
+  const { split, forceSingleLed, alwaysShow } =
     widgetSettings.getSettings<FlagDisplaySettings>('led-flags');
+
+  const hasContent = alwaysShow || flags.ledDisplayFlag !== 'none';
+
+  useWidgetAutoHide(hasContent);
 
   const [layout, setLayout] = useState({
     diodesPerBlock: 6,

--- a/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
+++ b/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
@@ -17,10 +17,6 @@ $board-padding: 4px;
   position: relative;
 }
 
-.animate {
-  visibility: visible;
-}
-
 .block {
   background-color: $led-surface-matrix;
   display: grid;
@@ -221,10 +217,6 @@ $board-padding: 4px;
   }
 }
 
-.flag-red {
-  visibility: visible;
-}
-
 .board.animate.flag-red {
   .diode[data-is-outer='true'],
   .diode[data-is-center='true'] {
@@ -256,10 +248,6 @@ $board-padding: 4px;
   100% {
     background-color: $led-red;
   }
-}
-
-.flag-green {
-  visibility: visible;
 }
 
 @for $max-r from 0 through 12 {

--- a/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
+++ b/src/widgets/LedFlagWidget/LedMatrix/LedMatrix.module.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 $diode-size: 10px;
 $diode-margin: 1px;
 $diode-cell: $diode-size + $diode-margin * 2;
@@ -261,7 +263,7 @@ $board-padding: 4px;
 
     @keyframes ledGreenFill-#{$max-r}-#{$r} {
       @for $s from 0 through $steps {
-        $pct: ($s / $steps) * 100%;
+        $pct: math.div($s, $steps) * 100%;
 
         $is-on: false;
         @if $s < $max-r {
@@ -276,7 +278,11 @@ $board-padding: 4px;
         }
 
         #{$pct} {
-          background-color: if($is-on, $led-green, $led-surface-panel);
+          @if $is-on {
+            background-color: $led-green;
+          } @else {
+            background-color: $led-surface-panel;
+          }
         }
       }
     }

--- a/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
+++ b/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
@@ -2,9 +2,7 @@
   width: 80%;
   aspect-ratio: 1;
   border-radius: 6px;
-  box-shadow:
-    0 15px 35px rgba(0, 0, 0, 0.8),
-    inset 0 0 0 1px #222;
+  box-shadow: inset 0 0 0 1px #222;
   background-color: $led-surface-off;
   position: relative;
 }

--- a/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
+++ b/src/widgets/LedFlagWidget/SingleLed/SingleLed.module.scss
@@ -9,10 +9,6 @@
   position: relative;
 }
 
-.animate {
-  visibility: visible;
-}
-
 .singleLedInner {
   position: absolute;
   inset: 8px;


### PR DESCRIPTION
CSS classes .animate, .flag-red, .flag-green explicitly set visibility:visible on LED elements, overriding the visibility:hidden applied by WidgetContainer when hideWidgetsWhenGameClosed is active. Also wires useWidgetAutoHide so the widget correctly reports its content state to the auto-hide store.