### PR TITLE
feat(screenshot): add --crop flag to slice overlay into individual widget PNGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,9 +260,12 @@ scripts\screenshot.bat      [windowId] [--out-dir <dir>] [--crop]
 npm run screenshot
 
 # Crop all visible widgets into docs/assets/screenshots/overlay/widgets/
-node scripts/screenshot.mjs overlay --crop
+npm run screenshot -- --crop
 
-# Custom output directory + crop
+# Custom output directory + crop (note the -- separator required by npm)
+npm run screenshot -- --out-dir docs/assets/screenshots/widgets --crop
+
+# Or call node directly (no -- needed)
 node scripts/screenshot.mjs overlay --out-dir docs/assets/screenshots/widgets --crop
 ```
 

--- a/README.md
+++ b/README.md
@@ -240,13 +240,33 @@ npm run tauri:build:release
 
 ## Screenshots
 
-You can capture the current state of the overlay or main window using the included scripts. Make sure the app is running in **dev mode** (`npm run tauri:dev`).
+Capture the current state of the overlay or main window using the included scripts. The app must be running in **dev mode** (`npm run tauri:dev`).
 
-- **Via npm:** `npm run screenshot` (captures overlay by default)
-- **Via Batch:** `scripts\screenshot.bat [overlay|main]`
-- **Output:** Saved to `docs/assets/screenshots/overlay/` (git-ignored).
+```
+node scripts/screenshot.mjs [windowId] [--out-dir <dir>] [--crop]
+scripts\screenshot.bat      [windowId] [--out-dir <dir>] [--crop]
+```
 
-To update permanent documentation assets, move files from `overlay/` to `widgets/`.
+| Argument          | Default                            | Description                                                           |
+| ----------------- | ---------------------------------- | --------------------------------------------------------------------- |
+| `windowId`        | `overlay`                          | Window to capture: `overlay` or `main`                                |
+| `--out-dir <dir>` | `docs/assets/screenshots/overlay/` | Directory where the full screenshot is saved                          |
+| `--crop`          | off                                | Also crop each visible widget into `<out-dir>/widgets/<widgetId>.png` |
+
+**Examples:**
+
+```bash
+# Full overlay screenshot → docs/assets/screenshots/overlay/screenshot-<ts>.png
+npm run screenshot
+
+# Crop all visible widgets into docs/assets/screenshots/overlay/widgets/
+node scripts/screenshot.mjs overlay --crop
+
+# Custom output directory + crop
+node scripts/screenshot.mjs overlay --out-dir docs/assets/screenshots/widgets --crop
+```
+
+The `docs/assets/screenshots/overlay/` directory is git-ignored. To update permanent documentation assets, copy files from there into `docs/assets/screenshots/widgets/`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -247,11 +247,11 @@ node scripts/screenshot.mjs [windowId] [--out-dir <dir>] [--crop]
 scripts\screenshot.bat      [windowId] [--out-dir <dir>] [--crop]
 ```
 
-| Argument          | Default                            | Description                                                           |
-| ----------------- | ---------------------------------- | --------------------------------------------------------------------- |
-| `windowId`        | `overlay`                          | Window to capture: `overlay` or `main`                                |
-| `--out-dir <dir>` | `docs/assets/screenshots/overlay/` | Directory where the full screenshot is saved                          |
-| `--crop`          | off                                | Also crop each visible widget into `<out-dir>/widgets/<widgetId>.png` |
+| Argument          | Default                                               | Description                                                   |
+| ----------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| `windowId`        | `overlay`                                             | Window to capture: `overlay` or `main`                        |
+| `--out-dir <dir>` | `overlay/` without `--crop`, `widgets/` with `--crop` | Directory where screenshots are saved                         |
+| `--crop`          | off                                                   | Also crop each visible widget into `<out-dir>/<widgetId>.png` |
 
 **Examples:**
 
@@ -259,11 +259,11 @@ scripts\screenshot.bat      [windowId] [--out-dir <dir>] [--crop]
 # Full overlay screenshot → docs/assets/screenshots/overlay/screenshot-<ts>.png
 npm run screenshot
 
-# Crop all visible widgets into docs/assets/screenshots/overlay/widgets/
+# Crop all visible widgets → docs/assets/screenshots/widgets/<widgetId>.png
 npm run screenshot -- --crop
 
 # Custom output directory + crop (note the -- separator required by npm)
-npm run screenshot -- --out-dir docs/assets/screenshots/widgets --crop
+npm run screenshot -- --out-dir docs/assets/screenshots/custom --crop
 
 # Or call node directly (no -- needed)
 node scripts/screenshot.mjs overlay --out-dir docs/assets/screenshots/widgets --crop

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "oxlint": "^1.67.0",
         "oxlint-tsgolint": "^0.23.0",
         "playwright": "^1.59.1",
+        "sharp": "^0.35.2",
         "storybook": "^10.3.5",
         "tauri-plugin-mcp-server": "^0.1.0",
         "typescript": "~5.9.2",
@@ -483,6 +484,17 @@
       },
       "peerDependencies": {
         "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emotion/hash": {
@@ -924,6 +936,581 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
@@ -5122,8 +5709,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -7452,9 +8039,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7523,6 +8110,51 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "oxlint": "^1.67.0",
     "oxlint-tsgolint": "^0.23.0",
     "playwright": "^1.59.1",
+    "sharp": "^0.35.2",
     "storybook": "^10.3.5",
     "tauri-plugin-mcp-server": "^0.1.0",
     "typescript": "~5.9.2",

--- a/scripts/screenshot.bat
+++ b/scripts/screenshot.bat
@@ -1,11 +1,10 @@
 @echo off
 :: Usage:
-::   screenshot.bat                          -> overlay, saves to docs/assets/screenshots/
-::   screenshot.bat overlay                  -> overlay window
-::   screenshot.bat main                     -> main settings window
-::   screenshot.bat overlay C:\path\to\out.png
+::   screenshot.bat                                    -> overlay, saves to docs/assets/screenshots/overlay/
+::   screenshot.bat overlay                            -> overlay window
+::   screenshot.bat main                               -> main settings window
+::   screenshot.bat overlay --out-dir C:\path\to\dir  -> custom output directory
+::   screenshot.bat overlay --crop                     -> also crop individual widgets into <out-dir>/widgets/
+::   screenshot.bat overlay --out-dir C:\path --crop  -> custom dir + crop widgets
 
-set WINDOW=%1
-if "%WINDOW%"=="" set WINDOW=overlay
-
-node "%~dp0screenshot.mjs" %WINDOW% %2
+node "%~dp0screenshot.mjs" %*

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -85,6 +85,8 @@ async function cropWidgets(pngBuffer, baseDir) {
       const els = document.querySelectorAll('[data-widget-id]');
       const result = [];
       for (const el of els) {
+        const style = getComputedStyle(el);
+        if (style.visibility === 'hidden' || style.display === 'none' || style.opacity === '0') continue;
         const rect = el.getBoundingClientRect();
         if (rect.width > 0 && rect.height > 0) {
           result.push({

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
-// Usage: node screenshot.mjs [windowId] [outputPath]
-//   windowId  - "overlay" or "main" (default: overlay)
+// Usage: node screenshot.mjs [windowId] [outputPath] [--crop]
+//   windowId   - "overlay" or "main" (default: overlay)
 //   outputPath - where to save PNG (default: docs/assets/screenshots/overlay/screenshot-<timestamp>.png)
+//   --crop     - also crop individual widgets into <outputPath>-widgets/<widgetId>.png
 
 import { writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import WebSocket from 'ws';
 
-const windowId = process.argv[2] || 'overlay';
+const args = process.argv.slice(2);
+const cropFlag = args.includes('--crop');
+const positional = args.filter((a) => a !== '--crop');
+
+const windowId = positional[0] || 'overlay';
 const defaultDir = path.join(
   process.cwd(),
   'docs',
@@ -16,44 +21,48 @@ const defaultDir = path.join(
   'overlay'
 );
 const outputPath =
-  process.argv[3] || path.join(defaultDir, `screenshot-${Date.now()}.png`);
+  positional[1] || path.join(defaultDir, `screenshot-${Date.now()}.png`);
 
-// Ensure directory exists
-try {
-  mkdirSync(path.dirname(outputPath), { recursive: true });
-} catch {
-  // Ignore if directory already exists
-}
+mkdirSync(path.dirname(outputPath), { recursive: true });
 
 const ws = new WebSocket('ws://localhost:9223');
 
 ws.on('open', () => {
-  const id = `req_${Date.now()}_screenshot`;
+  const screenshotId = `req_${Date.now()}_screenshot`;
   ws.send(
     JSON.stringify({
-      id,
+      id: screenshotId,
       command: 'capture_native_screenshot',
       args: { format: 'png', windowLabel: windowId },
     })
   );
 
-  ws.on('message', (data) => {
+  ws.on('message', async (data) => {
     try {
       const msg = JSON.parse(data.toString());
-      if (msg.id !== id) return;
-      ws.close();
+      if (msg.id !== screenshotId) return;
 
       if (!msg.success) {
         console.error('Error:', msg.error);
+        ws.close();
         process.exit(1);
       }
 
-      // data is a base64 data URL: "data:image/png;base64,..."
       const base64 = msg.data.replace(/^data:image\/\w+;base64,/, '');
-      writeFileSync(outputPath, Buffer.from(base64, 'base64'));
+      const pngBuffer = Buffer.from(base64, 'base64');
+      writeFileSync(outputPath, pngBuffer);
       console.log('Saved:', outputPath);
+
+      if (!cropFlag) {
+        ws.close();
+        return;
+      }
+
+      await cropWidgets(pngBuffer, outputPath);
+      ws.close();
     } catch (err) {
-      console.error('Failed to parse message:', err.message);
+      console.error('Failed:', err.message);
+      ws.close();
       process.exit(1);
     }
   });
@@ -64,3 +73,96 @@ ws.on('error', (err) => {
   console.error('Make sure the app is running in dev mode (npm run tauri dev)');
   process.exit(1);
 });
+
+async function cropWidgets(pngBuffer, screenshotPath) {
+  const { default: sharp } = await import('sharp');
+
+  const jsCode = `
+    (function() {
+      const els = document.querySelectorAll('[data-widget-id]');
+      const result = [];
+      for (const el of els) {
+        const rect = el.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          result.push({
+            id: el.dataset.widgetId,
+            x: Math.round(rect.left),
+            y: Math.round(rect.top),
+            width: Math.round(rect.width),
+            height: Math.round(rect.height),
+          });
+        }
+      }
+      return JSON.stringify(result);
+    })()
+  `;
+
+  const jsId = `req_${Date.now()}_js`;
+
+  return new Promise((resolve, reject) => {
+    const jsWs = new WebSocket('ws://localhost:9223');
+
+    jsWs.on('open', () => {
+      jsWs.send(
+        JSON.stringify({
+          id: jsId,
+          command: 'execute_script',
+          args: { script: jsCode, windowLabel: 'overlay' },
+        })
+      );
+    });
+
+    jsWs.on('message', async (data) => {
+      try {
+        const msg = JSON.parse(data.toString());
+        if (msg.id !== jsId) return;
+        jsWs.close();
+
+        if (!msg.success) {
+          console.error('JS execution failed:', msg.error);
+          reject(new Error(msg.error));
+          return;
+        }
+
+        const widgets = JSON.parse(msg.data);
+        if (!widgets.length) {
+          console.log('No visible widgets found to crop.');
+          resolve();
+          return;
+        }
+
+        const outDir = `${screenshotPath}-widgets`;
+        mkdirSync(outDir, { recursive: true });
+
+        const meta = await sharp(pngBuffer).metadata();
+        const imgWidth = meta.width;
+        const imgHeight = meta.height;
+
+        for (const widget of widgets) {
+          const left = Math.max(0, widget.x);
+          const top = Math.max(0, widget.y);
+          const width = Math.min(widget.width, imgWidth - left);
+          const height = Math.min(widget.height, imgHeight - top);
+
+          if (width <= 0 || height <= 0) continue;
+
+          const outFile = path.join(outDir, `${widget.id}.png`);
+          await sharp(pngBuffer)
+            .extract({ left, top, width, height })
+            .toFile(outFile);
+
+          console.log(`  Cropped: ${widget.id} → ${outFile}`);
+        }
+
+        resolve();
+      } catch (err) {
+        jsWs.close();
+        reject(err);
+      }
+    });
+
+    jsWs.on('error', (err) => {
+      reject(err);
+    });
+  });
+}

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -1,29 +1,32 @@
 #!/usr/bin/env node
-// Usage: node screenshot.mjs [windowId] [outputPath] [--crop]
-//   windowId   - "overlay" or "main" (default: overlay)
-//   outputPath - where to save PNG (default: docs/assets/screenshots/overlay/screenshot-<timestamp>.png)
-//   --crop     - also crop individual widgets into <outputPath>-widgets/<widgetId>.png
+// Usage: node screenshot.mjs [windowId] [--out-dir <dir>] [--crop]
+//   windowId      - "overlay" or "main" (default: overlay)
+//   --out-dir <d> - directory for the full screenshot (default: docs/assets/screenshots/overlay/)
+//   --crop        - also crop each visible widget into <out-dir>/widgets/<widgetId>.png
 
 import { writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
 import WebSocket from 'ws';
 
 const args = process.argv.slice(2);
+
 const cropFlag = args.includes('--crop');
-const positional = args.filter((a) => a !== '--crop');
+
+const outDirIndex = args.indexOf('--out-dir');
+const outDir =
+  outDirIndex !== -1 && args[outDirIndex + 1]
+    ? path.resolve(args[outDirIndex + 1])
+    : path.join(process.cwd(), 'docs', 'assets', 'screenshots', 'overlay');
+
+const positional = args.filter(
+  (a, i) => a !== '--crop' && a !== '--out-dir' && args[i - 1] !== '--out-dir'
+);
 
 const windowId = positional[0] || 'overlay';
-const defaultDir = path.join(
-  process.cwd(),
-  'docs',
-  'assets',
-  'screenshots',
-  'overlay'
-);
-const outputPath =
-  positional[1] || path.join(defaultDir, `screenshot-${Date.now()}.png`);
 
-mkdirSync(path.dirname(outputPath), { recursive: true });
+mkdirSync(outDir, { recursive: true });
+
+const outputPath = path.join(outDir, `screenshot-${Date.now()}.png`);
 
 const ws = new WebSocket('ws://localhost:9223');
 
@@ -58,7 +61,7 @@ ws.on('open', () => {
         return;
       }
 
-      await cropWidgets(pngBuffer, outputPath);
+      await cropWidgets(pngBuffer, outDir);
       ws.close();
     } catch (err) {
       console.error('Failed:', err.message);
@@ -74,7 +77,7 @@ ws.on('error', (err) => {
   process.exit(1);
 });
 
-async function cropWidgets(pngBuffer, screenshotPath) {
+async function cropWidgets(pngBuffer, baseDir) {
   const { default: sharp } = await import('sharp');
 
   const jsCode = `
@@ -131,8 +134,8 @@ async function cropWidgets(pngBuffer, screenshotPath) {
           return;
         }
 
-        const outDir = `${screenshotPath}-widgets`;
-        mkdirSync(outDir, { recursive: true });
+        const widgetsDir = path.join(baseDir, 'widgets');
+        mkdirSync(widgetsDir, { recursive: true });
 
         const meta = await sharp(pngBuffer).metadata();
         const imgWidth = meta.width;
@@ -146,7 +149,7 @@ async function cropWidgets(pngBuffer, screenshotPath) {
 
           if (width <= 0 || height <= 0) continue;
 
-          const outFile = path.join(outDir, `${widget.id}.png`);
+          const outFile = path.join(widgetsDir, `${widget.id}.png`);
           await sharp(pngBuffer)
             .extract({ left, top, width, height })
             .toFile(outFile);

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -2,7 +2,7 @@
 // Usage: node screenshot.mjs [windowId] [--out-dir <dir>] [--crop]
 //   windowId      - "overlay" or "main" (default: overlay)
 //   --out-dir <d> - directory for the full screenshot (default: docs/assets/screenshots/overlay/)
-//   --crop        - also crop each visible widget into <out-dir>/widgets/<widgetId>.png
+//   --crop        - also crop each visible widget into <out-dir>/<widgetId>.png
 
 import { writeFileSync, mkdirSync } from 'fs';
 import path from 'path';
@@ -65,7 +65,7 @@ ws.on('open', () => {
         return;
       }
 
-      await cropWidgets(pngBuffer, outDir);
+      await cropWidgets(ws, pngBuffer, outDir);
       ws.close();
     } catch (err) {
       console.error('Failed:', err.message);
@@ -81,7 +81,7 @@ ws.on('error', (err) => {
   process.exit(1);
 });
 
-async function cropWidgets(pngBuffer, baseDir) {
+async function cropWidgets(ws, pngBuffer, baseDir) {
   const { default: sharp } = await import('sharp');
 
   const jsCode = `
@@ -109,23 +109,11 @@ async function cropWidgets(pngBuffer, baseDir) {
   const jsId = `req_${Date.now()}_js`;
 
   return new Promise((resolve, reject) => {
-    const jsWs = new WebSocket('ws://localhost:9223');
-
-    jsWs.on('open', () => {
-      jsWs.send(
-        JSON.stringify({
-          id: jsId,
-          command: 'execute_js',
-          args: { script: jsCode, windowLabel: 'overlay' },
-        })
-      );
-    });
-
-    jsWs.on('message', async (data) => {
+    const onMessage = async (data) => {
       try {
         const msg = JSON.parse(data.toString());
         if (msg.id !== jsId) return;
-        jsWs.close();
+        ws.off('message', onMessage);
 
         if (!msg.success) {
           console.error('JS execution failed:', msg.error);
@@ -140,8 +128,7 @@ async function cropWidgets(pngBuffer, baseDir) {
           return;
         }
 
-        const widgetsDir = baseDir;
-        mkdirSync(widgetsDir, { recursive: true });
+        mkdirSync(baseDir, { recursive: true });
 
         const meta = await sharp(pngBuffer).metadata();
         const imgWidth = meta.width;
@@ -157,7 +144,7 @@ async function cropWidgets(pngBuffer, baseDir) {
 
           if (width <= 0 || height <= 0) continue;
 
-          const outFile = path.join(widgetsDir, `${widget.id}.png`);
+          const outFile = path.join(baseDir, `${widget.id}.png`);
           await sharp(pngBuffer)
             .extract({ left, top, width, height })
             .toFile(outFile);
@@ -167,13 +154,18 @@ async function cropWidgets(pngBuffer, baseDir) {
 
         resolve();
       } catch (err) {
-        jsWs.close();
+        ws.off('message', onMessage);
         reject(err);
       }
-    });
+    };
 
-    jsWs.on('error', (err) => {
-      reject(err);
-    });
+    ws.on('message', onMessage);
+    ws.send(
+      JSON.stringify({
+        id: jsId,
+        command: 'execute_js',
+        args: { script: jsCode, windowLabel: 'overlay' },
+      })
+    );
   });
 }

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -112,7 +112,7 @@ async function cropWidgets(pngBuffer, baseDir) {
         JSON.stringify({
           id: jsId,
           command: 'execute_js',
-          args: { code: jsCode, window_label: 'overlay' },
+          args: { script: jsCode, windowLabel: 'overlay' },
         })
       );
     });

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -150,8 +150,10 @@ async function cropWidgets(pngBuffer, baseDir) {
         for (const widget of widgets) {
           const left = Math.max(0, widget.x);
           const top = Math.max(0, widget.y);
-          const width = Math.min(widget.width, imgWidth - left);
-          const height = Math.min(widget.height, imgHeight - top);
+          const right = Math.min(imgWidth, widget.x + widget.width);
+          const bottom = Math.min(imgHeight, widget.y + widget.height);
+          const width = right - left;
+          const height = bottom - top;
 
           if (width <= 0 || height <= 0) continue;
 

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -13,10 +13,14 @@ const args = process.argv.slice(2);
 const cropFlag = args.includes('--crop');
 
 const outDirIndex = args.indexOf('--out-dir');
+const defaultOutDir = cropFlag
+  ? path.join(process.cwd(), 'docs', 'assets', 'screenshots', 'widgets')
+  : path.join(process.cwd(), 'docs', 'assets', 'screenshots', 'overlay');
+
 const outDir =
   outDirIndex !== -1 && args[outDirIndex + 1]
     ? path.resolve(args[outDirIndex + 1])
-    : path.join(process.cwd(), 'docs', 'assets', 'screenshots', 'overlay');
+    : defaultOutDir;
 
 const positional = args.filter(
   (a, i) => a !== '--crop' && a !== '--out-dir' && args[i - 1] !== '--out-dir'
@@ -136,7 +140,7 @@ async function cropWidgets(pngBuffer, baseDir) {
           return;
         }
 
-        const widgetsDir = path.join(baseDir, 'widgets');
+        const widgetsDir = baseDir;
         mkdirSync(widgetsDir, { recursive: true });
 
         const meta = await sharp(pngBuffer).metadata();

--- a/scripts/screenshot.mjs
+++ b/scripts/screenshot.mjs
@@ -111,8 +111,8 @@ async function cropWidgets(pngBuffer, baseDir) {
       jsWs.send(
         JSON.stringify({
           id: jsId,
-          command: 'execute_script',
-          args: { script: jsCode, windowLabel: 'overlay' },
+          command: 'execute_js',
+          args: { code: jsCode, window_label: 'overlay' },
         })
       );
     });

--- a/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
@@ -210,6 +210,7 @@ export const WidgetContainer = observer(
     return (
       <div
         className={`${styles.container} ${shouldHide ? styles.hidden : ''}`}
+        data-widget-id={widgetId}
         style={{
           left: x,
           top: y,


### PR DESCRIPTION

  ## Summary

  - Added `--crop` flag to `scripts/screenshot.mjs` — after capturing the overlay screenshot, executes JS in the webview to collect
  `getBoundingClientRect()` of every `[data-widget-id]` element, then slices the PNG into per-widget files using `sharp`
  - Added `--out-dir <dir>` flag to control the output directory; defaults to `docs/assets/screenshots/overlay/` for a plain screenshot and
  `docs/assets/screenshots/widgets/` when `--crop` is used
  - Added `data-widget-id` attribute to `WidgetContainer` root element so widgets are queryable from JS
  - Hidden widgets (`visibility: hidden`, `display: none`, `opacity: 0`) are skipped during crop
  - Updated `scripts/screenshot.bat` to pass all args through
  - Updated README Screenshots section with argument table and usage examples (including the `--` separator required by npm)