### PR TITLE
fix(settings): strip \\.\\ prefix from Win32 monitor names correctly

### DIFF
--- a/src/app/main/components/SettingsPage/SettingsPage.tsx
+++ b/src/app/main/components/SettingsPage/SettingsPage.tsx
@@ -19,7 +19,7 @@ import styles from './SettingsPage.module.scss';
 import { useAppSettingsStore, useUnitsStore } from '@store/root-store-context';
 
 const isDev = import.meta.env.DEV;
-const WIN32_DISPLAY_PREFIX = /^\\\\\.\\\\/;
+const WIN32_DISPLAY_PREFIX = /^\\\\\.\\/;
 
 interface CardProps {
   title?: string;


### PR DESCRIPTION
Closed #230