### PR TITLE
feat(widgets): add NO DATA placeholder to table widgets

### DIFF
--- a/src/components/shared/NoDataPlaceholder/NoDataPlaceholder.module.scss
+++ b/src/components/shared/NoDataPlaceholder/NoDataPlaceholder.module.scss
@@ -1,0 +1,16 @@
+.placeholder {
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  min-height: ws(60);
+}
+
+.text {
+  font-family: $font-widget;
+  font-size: fs(sm);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  color: $widget-text-secondary;
+  text-transform: uppercase;
+}

--- a/src/components/shared/NoDataPlaceholder/NoDataPlaceholder.tsx
+++ b/src/components/shared/NoDataPlaceholder/NoDataPlaceholder.tsx
@@ -1,0 +1,7 @@
+import styles from './NoDataPlaceholder.module.scss';
+
+export const NoDataPlaceholder = () => (
+  <div className={styles.placeholder}>
+    <span className={styles.text}>NO DATA</span>
+  </div>
+);

--- a/src/widgets/LapLogWidget/LapLogWidget.tsx
+++ b/src/widgets/LapLogWidget/LapLogWidget.tsx
@@ -1,8 +1,10 @@
 import { observer } from 'mobx-react-lite';
 import { WidgetPanel } from '@/components/shared/WidgetPanel/WidgetPanel';
+import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder/NoDataPlaceholder';
 import {
   useBackendComputedStore,
   usePlayerStore,
+  useSimStore,
 } from '@store/root-store-context';
 import { formatLapTime } from '@utils/formatters/telemetry-format';
 import { formatDelta, getDeltaState } from '@utils/widget/delta-utils';
@@ -15,12 +17,15 @@ export const LapLogWidget = observer(() => {
   const { lapHistory, lastCompletedLap: _lastCompleted } =
     useBackendComputedStore();
   const { lapTiming } = usePlayerStore();
+  const sim = useSimStore();
 
   const lapNum = lapTiming?.lap ?? null;
   const currentLapTime = lapTiming?.lap_current_lap_time ?? 0;
   const bestLapTime = lapTiming?.lap_best_lap_time ?? null;
 
   const visibleHistory = lapHistory.slice(0, HISTORY_SHOW_SIZE);
+
+  const hasData = sim.isConnected && lapTiming != null;
 
   return (
     <WidgetPanel direction="column" gap={0} minWidth={0}>
@@ -36,28 +41,36 @@ export const LapLogWidget = observer(() => {
         </div>
       </div>
 
-      <LapRow
-        lapLabel={`L${lapNum ?? '--'}`}
-        time={formatLapTime(currentLapTime)}
-        isLive
-      />
+      {!hasData ? (
+        <NoDataPlaceholder />
+      ) : (
+        <>
+          <LapRow
+            lapLabel={`L${lapNum ?? '--'}`}
+            time={formatLapTime(currentLapTime)}
+            isLive
+          />
 
-      {visibleHistory.map((entry) => (
-        <LapRow
-          key={entry.lapNum}
-          lapLabel={`L${entry.lapNum}`}
-          time={entry.lapTime !== null ? formatLapTime(entry.lapTime) : null}
-          deltaLabel={entry.isBest ? '★ BEST' : formatDelta(entry.delta)}
-          deltaVariant={
-            entry.isBest
-              ? 'best'
-              : entry.delta !== null
-                ? getDeltaState(entry.delta)
-                : undefined
-          }
-          isBest={entry.isBest}
-        />
-      ))}
+          {visibleHistory.map((entry) => (
+            <LapRow
+              key={entry.lapNum}
+              lapLabel={`L${entry.lapNum}`}
+              time={
+                entry.lapTime !== null ? formatLapTime(entry.lapTime) : null
+              }
+              deltaLabel={entry.isBest ? '★ BEST' : formatDelta(entry.delta)}
+              deltaVariant={
+                entry.isBest
+                  ? 'best'
+                  : entry.delta !== null
+                    ? getDeltaState(entry.delta)
+                    : undefined
+              }
+              isBest={entry.isBest}
+            />
+          ))}
+        </>
+      )}
     </WidgetPanel>
   );
 });

--- a/src/widgets/RelativeWidget/RelativeContent/RelativeContent.tsx
+++ b/src/widgets/RelativeWidget/RelativeContent/RelativeContent.tsx
@@ -3,12 +3,17 @@ import { observer } from 'mobx-react-lite';
 
 import { useVisibleRowCount } from '@hooks/common/useVisibleRowCount';
 import { DriverRow } from '@widgets/RelativeWidget/DriverRow/DriverRow';
+import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder/NoDataPlaceholder';
+import {
+  useBackendComputedStore,
+  useSimStore,
+} from '@store/root-store-context';
 
 import styles from './RelativeContent.module.scss';
-import { useBackendComputedStore } from '@store/root-store-context';
 
 export const RelativeContent = observer(() => {
   const computed = useBackendComputedStore();
+  const sim = useSimStore();
 
   const entries = computed.relativeEntries;
 
@@ -35,6 +40,12 @@ export const RelativeContent = observer(() => {
 
     return entries.slice(playerIdx - above, playerIdx + below + 1);
   }, [entries, visibleRowCount]);
+
+  const hasData = sim.isConnected && entries.length > 0;
+
+  if (!hasData) {
+    return <NoDataPlaceholder />;
+  }
 
   return (
     <div ref={driverListRef} className={styles.driverList}>

--- a/src/widgets/SectorMatrixWidget/SectorMatrixWidget.tsx
+++ b/src/widgets/SectorMatrixWidget/SectorMatrixWidget.tsx
@@ -1,7 +1,9 @@
-﻿import { observer } from 'mobx-react-lite';
+import { observer } from 'mobx-react-lite';
 import { WidgetPanel } from '@/components/shared/WidgetPanel/WidgetPanel';
+import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder/NoDataPlaceholder';
 import {
   useSessionStore,
+  useSimStore,
   useWidgetSettingsStore,
 } from '@store/root-store-context';
 import type { SectorMatrixWidgetSettings } from '@/types/widget-settings';
@@ -11,20 +13,28 @@ import { SectorFooter } from './SectorFooter/SectorFooter';
 
 export const SectorMatrixWidget = observer(() => {
   const { sessionInfo } = useSessionStore();
+  const sim = useSimStore();
   const widgetSettings = useWidgetSettingsStore();
 
   const { showSectors } =
     widgetSettings.getSettings<SectorMatrixWidgetSettings>('sector-matrix');
 
   const sectorCount = sessionInfo?.sectors.length || 3;
+  const hasData = sim.isConnected && sessionInfo != null;
 
   return (
     <WidgetPanel direction="column" gap={0} minWidth={0}>
       <SectorHeader sectorCount={sectorCount} />
 
-      {showSectors && <SectorGrid sectorCount={sectorCount} />}
+      {!hasData ? (
+        <NoDataPlaceholder />
+      ) : (
+        <>
+          {showSectors && <SectorGrid sectorCount={sectorCount} />}
 
-      <SectorFooter />
+          <SectorFooter />
+        </>
+      )}
     </WidgetPanel>
   );
 });

--- a/src/widgets/SectorMatrixWidget/SectorMatrixWidget.tsx
+++ b/src/widgets/SectorMatrixWidget/SectorMatrixWidget.tsx
@@ -24,12 +24,12 @@ export const SectorMatrixWidget = observer(() => {
 
   return (
     <WidgetPanel direction="column" gap={0} minWidth={0}>
-      <SectorHeader sectorCount={sectorCount} />
-
       {!hasData ? (
         <NoDataPlaceholder />
       ) : (
         <>
+          <SectorHeader sectorCount={sectorCount} />
+
           {showSectors && <SectorGrid sectorCount={sectorCount} />}
 
           <SectorFooter />

--- a/src/widgets/StandingsWidget/StandingsContent/StandingsContent.tsx
+++ b/src/widgets/StandingsWidget/StandingsContent/StandingsContent.tsx
@@ -4,6 +4,7 @@ import type { DriverGroup } from '@/types';
 import type { StandingsWidgetSettings } from '@/types/widget-settings';
 import {
   useBackendComputedStore,
+  useSimStore,
   useStandingsWidgetStore,
   useWidgetSettingsStore,
 } from '@store/root-store-context';
@@ -12,6 +13,7 @@ import {
   sliceWithPlayerPin,
 } from '@utils/widget/standings-utils';
 import { useVisibleRowCount } from '@/hooks/common/useVisibleRowCount';
+import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder/NoDataPlaceholder';
 import { SessionHeader } from '@widgets/StandingsWidget/SessionHeader/SessionHeader';
 import { ClassGroup } from '@widgets/StandingsWidget/ClassGroup/ClassGroup';
 import { ClassSwitcher } from '@widgets/StandingsWidget/ClassSwitcher/ClassSwitcher';
@@ -22,6 +24,7 @@ import styles from './StandingsContent.module.scss';
 
 export const StandingsContent = observer(() => {
   const { standings } = useBackendComputedStore();
+  const sim = useSimStore();
   const widgetSettings = useWidgetSettingsStore();
   const standingsWidget = useStandingsWidgetStore();
   const { allClassGroups } = standingsWidget;
@@ -81,32 +84,43 @@ export const StandingsContent = observer(() => {
     };
   };
 
+  const hasData = sim.isConnected && standings != null;
+
   return (
     <>
       <SessionHeader />
 
-      <ClassSwitcher />
+      {!hasData ? (
+        <NoDataPlaceholder />
+      ) : (
+        <>
+          <ClassSwitcher />
 
-      <div ref={listRef} className={styles.listWrap}>
-        <StandingsHeader />
+          <div ref={listRef} className={styles.listWrap}>
+            <StandingsHeader />
 
-        {isGrouped ? (
-          allClassGroups.map((group) => (
-            <ClassGroup
-              key={group.classId}
-              group={{
-                ...group,
-                drivers: sliceWithPlayerPin(group.drivers, rowsPerGroupedClass),
-              }}
-              showHeader
-            />
-          ))
-        ) : (
-          <ClassGroup group={displayGroup()} />
-        )}
-      </div>
+            {isGrouped ? (
+              allClassGroups.map((group) => (
+                <ClassGroup
+                  key={group.classId}
+                  group={{
+                    ...group,
+                    drivers: sliceWithPlayerPin(
+                      group.drivers,
+                      rowsPerGroupedClass
+                    ),
+                  }}
+                  showHeader
+                />
+              ))
+            ) : (
+              <ClassGroup group={displayGroup()} />
+            )}
+          </div>
 
-      <SessionFooter />
+          <SessionFooter />
+        </>
+      )}
     </>
   );
 });

--- a/src/widgets/StandingsWidget/StandingsContent/StandingsContent.tsx
+++ b/src/widgets/StandingsWidget/StandingsContent/StandingsContent.tsx
@@ -84,7 +84,8 @@ export const StandingsContent = observer(() => {
     };
   };
 
-  const hasData = sim.isConnected && standings != null;
+  const hasData =
+    sim.isConnected && standings != null && standings.entries.length > 0;
 
   return (
     <>


### PR DESCRIPTION
NoDataPlaceholder is now a dumb UI component. Each widget checks its own data condition (isConnected + relevant frame/array) and renders the placeholder itself when data is absent.

  Affected: StandingsContent, RelativeContent, LapLogWidget, SectorMatrixWidget

 Closed #97