### PR TITLE
fix(ci): remove broken negation pattern from ci filter

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -10,5 +10,12 @@ js:
   - 'index.html'
 rust:
   - 'src-tauri/**'
-ci:
-  - '.github/**'
+ci-js:
+  - '.github/workflows/reusable-quality.yml'
+  - '.github/workflows/pr-quality-check.yml'
+  - '.github/actions/**'
+  - '.github/filters.yml'
+ci-rust:
+  - '.github/workflows/reusable-quality.yml'
+  - '.github/actions/**'
+  - '.github/filters.yml'

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -12,4 +12,3 @@ rust:
   - 'src-tauri/**'
 ci:
   - '.github/**'
-  - '!.github/workflows/codeql.yml'

--- a/.github/workflows/pr-comment-preview.yml
+++ b/.github/workflows/pr-comment-preview.yml
@@ -51,7 +51,8 @@ jobs:
 
             const artifacts = data.artifacts.filter(a => !a.expired);
             if (artifacts.length === 0) {
-              core.setFailed('No artifacts found');
+              core.info('No artifacts found — build was likely skipped, nothing to comment');
+              core.setOutput('skip', 'true');
               return;
             }
 

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -15,7 +15,8 @@ jobs:
     outputs:
       js: ${{ steps.filter.outputs.js }}
       rust: ${{ steps.filter.outputs.rust }}
-      ci: ${{ steps.filter.outputs.ci }}
+      ci-js: ${{ steps.filter.outputs.ci-js }}
+      ci-rust: ${{ steps.filter.outputs.ci-rust }}
       app: ${{ steps.filter.outputs.js == 'true' || steps.filter.outputs.rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
@@ -30,7 +31,7 @@ jobs:
     name: Frontend
     needs: check-changes
     runs-on: ubuntu-latest
-    if: ${{ inputs.force_all || needs.check-changes.outputs.js == 'true' || needs.check-changes.outputs.ci == 'true' }}
+    if: ${{ inputs.force_all || needs.check-changes.outputs.js == 'true' || needs.check-changes.outputs.ci-js == 'true' }}
     steps:
       - uses: actions/checkout@v5
 
@@ -59,7 +60,7 @@ jobs:
     name: Rust
     needs: check-changes
     runs-on: windows-latest
-    if: ${{ inputs.force_all || needs.check-changes.outputs.rust == 'true' || needs.check-changes.outputs.ci == 'true' }}
+    if: ${{ inputs.force_all || needs.check-changes.outputs.rust == 'true' || needs.check-changes.outputs.ci-rust == 'true' }}
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
The '!.github/workflows/codeql.yml' rule was OR-matched as 'everything except codeql.yml', so ci matched src files on every PR and always triggered both frontend and rust checks.