### PR TITLE
  feat(settings): hide widgets when player is in the garage

### DIFF
--- a/src/app/main/components/SettingsPage/SettingsPage.tsx
+++ b/src/app/main/components/SettingsPage/SettingsPage.tsx
@@ -165,6 +165,21 @@ export const SettingsPage = observer(() => {
               onChange={(v) => appSettings.setHideWidgetsWhenGameClosed(v)}
             />
           </div>
+
+          <div className={styles.fieldRow}>
+            <div className={styles.fieldTexts}>
+              <div className={styles.fieldTitle}>Hide in Garage</div>
+
+              <div className={styles.fieldDesc}>
+                Hide widgets when the car is in the garage.
+              </div>
+            </div>
+
+            <Switch
+              checked={appSettings.appSettings.hideWidgetsInGarage}
+              onChange={(v) => appSettings.setHideWidgetsInGarage(v)}
+            />
+          </div>
         </div>
       </Card>
 

--- a/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
@@ -50,7 +50,7 @@ export const WidgetContainer = observer(
     });
 
     const isConnected = simStore.status === 'connected';
-    const isOnTrack = player.carStatus?.is_on_track ?? true;
+    const isOnTrack = player.isOnTrack;
 
     const shouldHide =
       (appSettings.hideWidgetsWhenGameClosed && !isConnected && !dragMode) ||

--- a/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
+++ b/src/app/overlay/components/WidgetContainer/WidgetContainer.tsx
@@ -6,6 +6,7 @@ import { WidgetIdContext } from './WidgetIdContext';
 import { WidgetDragToolbar } from '@app/overlay/components/WidgetDragToolbar/WidgetDragToolbar';
 import {
   useAppSettingsStore,
+  usePlayerStore,
   useSimStore,
   useWidgetAutoHideStore,
   useWidgetSettingsStore,
@@ -25,6 +26,7 @@ export const WidgetContainer = observer(
 
     const simStore = useSimStore();
     const widgetAutoHide = useWidgetAutoHideStore();
+    const player = usePlayerStore();
 
     const widget = widgetSettings.getWidget(widgetId);
 
@@ -48,9 +50,14 @@ export const WidgetContainer = observer(
     });
 
     const isConnected = simStore.status === 'connected';
+    const isOnTrack = player.carStatus?.is_on_track ?? true;
 
     const shouldHide =
       (appSettings.hideWidgetsWhenGameClosed && !isConnected && !dragMode) ||
+      (appSettings.hideWidgetsInGarage &&
+        !isOnTrack &&
+        isConnected &&
+        !dragMode) ||
       (!widgetAutoHide.isVisible(widgetId) && !dragMode);
 
     const backgroundColor =

--- a/src/store/data/player.store.ts
+++ b/src/store/data/player.store.ts
@@ -19,6 +19,10 @@ export class PlayerStore {
     makeAutoObservable(this);
   }
 
+  get isOnTrack(): boolean {
+    return this.carStatus?.is_on_track ?? true;
+  }
+
   updateCarDynamics(frame: CarDynamicsFrame) {
     this.carDynamics = frame;
   }

--- a/src/store/settings/app-settings.store.ts
+++ b/src/store/settings/app-settings.store.ts
@@ -8,6 +8,7 @@ const DEFAULT_APP_SETTINGS = {
   dragHotkey: 'F9',
   hideAllWidgetsHotkey: 'F10',
   hideWidgetsWhenGameClosed: false,
+  hideWidgetsInGarage: false,
   hideAllWidgets: false,
   autoUpdate: true,
   updateCheckInterval: 3,
@@ -208,6 +209,10 @@ export class AppSettingsStore {
 
   setHideWidgetsWhenGameClosed(value: boolean) {
     this.appSettings.hideWidgetsWhenGameClosed = value;
+  }
+
+  setHideWidgetsInGarage(value: boolean) {
+    this.appSettings.hideWidgetsInGarage = value;
   }
 
   setOverlayMonitorIndex(value: number | null) {

--- a/src/store/sync/events.ts
+++ b/src/store/sync/events.ts
@@ -46,6 +46,13 @@ export const setupOverlayListeners = async (
     })
   );
   unlistens.push(
+    await listen<boolean>('hide-widgets-in-garage-changed', (e) => {
+      runInAction(() => {
+        root.appSettings.appSettings.hideWidgetsInGarage = e.payload;
+      });
+    })
+  );
+  unlistens.push(
     await listen<UnitSystem>('units-changed', (e) => {
       runInAction(() => root.units.setSystem(e.payload));
     })
@@ -75,6 +82,8 @@ export const emitHideAllWidgets = (val: boolean) =>
   emitTo(OVERLAY, 'hide-all-widgets-changed', val);
 export const emitHideWidgetsWhenGameClosed = (val: boolean) =>
   emitTo(OVERLAY, 'hide-widgets-when-game-closed-changed', val);
+export const emitHideWidgetsInGarage = (val: boolean) =>
+  emitTo(OVERLAY, 'hide-widgets-in-garage-changed', val);
 export const emitUnitsChanged = (system: UnitSystem) =>
   emitTo(OVERLAY, 'units-changed', system);
 export const emitStandingsClassIndex = (index: number) =>

--- a/src/store/sync/sync-init.ts
+++ b/src/store/sync/sync-init.ts
@@ -14,6 +14,7 @@ import {
   emitDragMode,
   emitHideAllWidgets,
   emitHideWidgetsWhenGameClosed,
+  emitHideWidgetsInGarage,
   emitUnitsChanged,
   emitStandingsClassIndex,
   emitWidgetSettingsUpdated,
@@ -77,6 +78,13 @@ export const initMainSync = async (root: RootStore) => {
           () => root.appSettings.appSettings.hideWidgetsWhenGameClosed,
           (v) => {
             void emitHideWidgetsWhenGameClosed(v);
+            void onSave();
+          }
+        ),
+        reaction(
+          () => root.appSettings.appSettings.hideWidgetsInGarage,
+          (v) => {
+            void emitHideWidgetsInGarage(v);
             void onSave();
           }
         ),


### PR DESCRIPTION
  Add "Hide in Garage" toggle that hides all overlay widgets when
  is_on_track is false (car is in garage). Synced main → overlay
  via hide-widgets-in-garage-changed event.

Closed #244