### PR TITLE
fix(hooks): use callback ref in useVisibleRowCount to fix count freeze on conditional render

### DIFF
--- a/src/hooks/common/useVisibleRowCount.ts
+++ b/src/hooks/common/useVisibleRowCount.ts
@@ -39,14 +39,14 @@ export const useVisibleRowCount = <T extends HTMLElement>(
           rowPx = firstReal.getBoundingClientRect().height;
         }
 
-        if (rowPx <= 0) {
+        if (!(rowPx > 0)) {
           const rootFontSize = parseFloat(
             getComputedStyle(document.documentElement).fontSize
           );
           rowPx = rowHeightRem * rootFontSize;
         }
 
-        if (rowPx <= 0) return;
+        if (!(rowPx > 0)) return;
 
         const next = Math.max(minRows, Math.floor(el.clientHeight / rowPx));
         dispatch(next);

--- a/src/hooks/common/useVisibleRowCount.ts
+++ b/src/hooks/common/useVisibleRowCount.ts
@@ -1,93 +1,88 @@
-import { useEffect, useReducer, useRef, type RefObject } from 'react';
+import { useCallback, useReducer, useRef, type RefCallback } from 'react';
 
-/**
- * Measures a container's height and returns how many rows of `rowHeight`
- * pixels fit inside it. Re-measures on resize via ResizeObserver.
- */
-/**
- * Measures a container's height and returns how many rows of `rowHeightRem`
- * (in rem units, evaluated against the document root font-size which the
- * WidgetWrapper rescales) fit inside it. Re-measures on resize.
- */
 export const useVisibleRowCount = <T extends HTMLElement>(
   rowHeightRem: number,
   minRows = 1,
   rowSelector?: string
-): { ref: RefObject<T | null>; count: number } => {
-  const ref = useRef<T | null>(null);
+): { ref: RefCallback<T>; count: number } => {
   const [count, dispatch] = useReducer(
     (state: number, action: number) => (state === action ? state : action),
     minRows
   );
 
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
+  const cleanupRef = useRef<(() => void) | null>(null);
 
-    const measure = () => {
-      // Prefer measuring an actual rendered child — it accounts for borders,
-      // padding, line-height, font scaling and any descendant layout. Falls
-      // back to a rem-based estimate when the list has no real children yet.
-      let rowPx = 0;
-      let firstReal: HTMLElement | null = null;
-
-      if (rowSelector) {
-        firstReal = el.querySelector(rowSelector);
-      } else {
-        firstReal =
-          Array.from(el.children).find(
-            (c): c is HTMLElement =>
-              c instanceof HTMLElement && !c.className.includes('Placeholder')
-          ) ?? null;
+  const ref = useCallback(
+    (el: T | null) => {
+      if (cleanupRef.current) {
+        cleanupRef.current();
+        cleanupRef.current = null;
       }
 
-      if (firstReal) {
-        rowPx = firstReal.getBoundingClientRect().height;
-      }
-      if (rowPx <= 0) {
-        const rootFontSize = parseFloat(
-          getComputedStyle(document.documentElement).fontSize
-        );
-        rowPx = rowHeightRem * rootFontSize;
-      }
-      if (rowPx <= 0) return;
-      const next = Math.max(minRows, Math.floor(el.clientHeight / rowPx));
-      dispatch(next);
-    };
+      if (!el) return;
 
-    let rafId = 0;
-    const scheduleMeasure = () => {
-      cancelAnimationFrame(rafId);
-      rafId = requestAnimationFrame(measure);
-    };
+      const measure = () => {
+        let rowPx = 0;
+        let firstReal: HTMLElement | null = null;
 
-    scheduleMeasure();
+        if (rowSelector) {
+          firstReal = el.querySelector(rowSelector);
+        } else {
+          firstReal =
+            Array.from(el.children).find(
+              (c): c is HTMLElement =>
+                c instanceof HTMLElement && !c.className.includes('Placeholder')
+            ) ?? null;
+        }
 
-    // Fallback: if the first rAF fires before layout is complete (height = 0),
-    // retry at 100ms and 400ms after mount so the count is always correct on
-    // cold start without needing a manual resize.
-    const t1 = setTimeout(scheduleMeasure, 100);
-    const t2 = setTimeout(scheduleMeasure, 400);
+        if (firstReal) {
+          rowPx = firstReal.getBoundingClientRect().height;
+        }
 
-    const ro = new ResizeObserver(scheduleMeasure);
-    ro.observe(el);
-    // Root font-size also changes when WidgetWrapper rescales — observe that.
-    const rootRo = new ResizeObserver(scheduleMeasure);
-    rootRo.observe(document.documentElement);
-    // Re-measure when children appear/change (real rows replacing placeholders).
-    // Uses scheduleMeasure so back-to-back DOM mutations from a React re-render
-    // are coalesced into a single rAF tick, preventing oscillation loops.
-    const mo = new MutationObserver(scheduleMeasure);
-    mo.observe(el, { childList: true, subtree: false });
-    return () => {
-      cancelAnimationFrame(rafId);
-      clearTimeout(t1);
-      clearTimeout(t2);
-      ro.disconnect();
-      rootRo.disconnect();
-      mo.disconnect();
-    };
-  }, [rowHeightRem, minRows, rowSelector]);
+        if (rowPx <= 0) {
+          const rootFontSize = parseFloat(
+            getComputedStyle(document.documentElement).fontSize
+          );
+          rowPx = rowHeightRem * rootFontSize;
+        }
+
+        if (rowPx <= 0) return;
+
+        const next = Math.max(minRows, Math.floor(el.clientHeight / rowPx));
+        dispatch(next);
+      };
+
+      let rafId = 0;
+      const scheduleMeasure = () => {
+        cancelAnimationFrame(rafId);
+        rafId = requestAnimationFrame(measure);
+      };
+
+      scheduleMeasure();
+
+      const t1 = setTimeout(scheduleMeasure, 100);
+      const t2 = setTimeout(scheduleMeasure, 400);
+
+      const ro = new ResizeObserver(scheduleMeasure);
+      ro.observe(el);
+
+      const rootRo = new ResizeObserver(scheduleMeasure);
+      rootRo.observe(document.documentElement);
+
+      const mo = new MutationObserver(scheduleMeasure);
+      mo.observe(el, { childList: true, subtree: false });
+
+      cleanupRef.current = () => {
+        cancelAnimationFrame(rafId);
+        clearTimeout(t1);
+        clearTimeout(t2);
+        ro.disconnect();
+        rootRo.disconnect();
+        mo.disconnect();
+      };
+    },
+    [rowHeightRem, minRows, rowSelector]
+  );
 
   return { ref, count };
 };


### PR DESCRIPTION
When listRef was inside a conditional block (hasData guard added in #248), useEffect saw ref.current = null on mount and bailed out — ResizeObserver never attached, count stayed at minRows. Switching to a RefCallback ensures setup runs exactly when the element is added to the DOM.